### PR TITLE
Use xcb-xkb and xkbcommon for input event handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 WindowAbstractions = "e18202ca-4a7d-4de8-b056-fa6bbd7de157"
 Xorg_libxcb_jll = "c7cfdc94-dc32-55de-ac96-5a1b8d977c5b"
 Xorg_xcb_util_keysyms_jll = "975044d2-76e6-5fbe-bf08-97ce7c6574c7"
+xkbcommon_jll = "d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
 
 [compat]
 julia = "1.5"

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ xkbcommon_jll = "d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
 
 [compat]
 julia = "1.5"
+xkbcommon_jll = "0.9.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/gen/Libxcb.jl
+++ b/gen/Libxcb.jl
@@ -1,6 +1,6 @@
 module Libxcb
 
-import Xorg_libxcb_jll:libxcb
+import Xorg_libxcb_jll:libxcb, libxcb_xkb
 import Xorg_xcb_util_keysyms_jll:libxcb_keysyms
 
 using CEnum

--- a/gen/Libxkb.jl
+++ b/gen/Libxkb.jl
@@ -1,3 +1,5 @@
+module Libxkb
+
 import xkbcommon_jll
 
 using CEnum
@@ -14,4 +16,6 @@ foreach(names(@__MODULE__, all=true)) do s
     if startswith(string(s), r"(?:X|XKB|xkb)")
         @eval export $s
     end
+end
+
 end

--- a/gen/Libxkb.jl
+++ b/gen/Libxkb.jl
@@ -1,0 +1,17 @@
+import xkbcommon_jll
+
+using CEnum
+
+libxkbcommon = xkbcommon_jll.libxkbcommon
+
+const FILE=Ptr{Cvoid}
+
+include("xkb_common.jl")
+include("xkb_api.jl")
+
+# export everything
+foreach(names(@__MODULE__, all=true)) do s
+    if startswith(string(s), r"(?:X|XKB|xkb)")
+        @eval export $s
+    end
+end

--- a/gen/Libxkb.jl
+++ b/gen/Libxkb.jl
@@ -4,16 +4,18 @@ import xkbcommon_jll
 
 using CEnum
 
-libxkbcommon = xkbcommon_jll.libxkbcommon
+const libxkbcommon = xkbcommon_jll.libxkbcommon
+const libxkbcommon_x11 = first(filter( x -> occursin("libxkbcommon-x11", basename(x)), readdir(joinpath(xkbcommon_jll.artifact_dir, "lib"), join=true)))
 
 const FILE=Ptr{Cvoid}
 
+include("xcb_common.jl")
 include("xkb_common.jl")
 include("xkb_api.jl")
 
 # export everything
 foreach(names(@__MODULE__, all=true)) do s
-    if startswith(string(s), r"(?:X|XKB|xkb)")
+    if startswith(string(s), r"(?:X|XKB|xkb)") && !startswith(string(s), r"(?:XCB|xcb)")
         @eval export $s
     end
 end

--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -7,7 +7,7 @@ xcb_include_dir = joinpath(Xorg_libxcb_jll.artifact_dir, "include", "xcb")
 xcb_util_keysims_dir = joinpath(Xorg_xcb_util_keysyms_jll.artifact_dir, "include", "xcb")
 xkb_include_dir = joinpath(xkbcommon_jll.artifact_dir, "include", "xkbcommon")
 xkb_headers = joinpath.(Ref(xkb_include_dir), ["xkbcommon.h", "xkbcommon-x11.h"])
-xcb_headers =  [joinpath(xcb_include_dir, "xcb.h"), joinpath(xcb_util_keysims_dir, "xcb_keysyms.h")]
+xcb_headers = [joinpath.(Ref(xcb_include_dir), ["xkb.h"])..., joinpath(xcb_util_keysims_dir, "xcb_keysyms.h")]
 
 # Set up include paths
 clang_xcb_includes = [xcb_include_dir, xcb_util_keysims_dir]
@@ -28,7 +28,7 @@ wc_xcb = init(;
                         clang_includes=clang_xcb_includes,
                         clang_args=clang_extraargs,
                         header_wrapped=wrap_header,
-                        header_library=x -> endswith(x, "xcb_keysyms.h") ? "libxcb_keysyms" : "libxcb",
+                        header_library=x -> basename(x) == "xcb_keysyms.h" ? "libxcb_keysyms" : basename(x) == "xkb.h" ? "libxcb_xkb" : "libxcb",
                         clang_diagnostics=true,
                         )
 run(wc_xcb)
@@ -40,7 +40,7 @@ wc_xkb = init(;
                         clang_includes=clang_xkb_includes,
                         clang_args=clang_extraargs,
                         header_wrapped=wrap_header,
-                        header_library=x -> "libxkbcommon",
+                        header_library=x -> endswith(x, "xkbcommon-x11.h") ? "libxkbcommon_x11" : "libxkbcommon",
                         clang_diagnostics=true,
                         )
 run(wc_xkb)

--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -6,7 +6,7 @@ import xkbcommon_jll
 xcb_include_dir = joinpath(Xorg_libxcb_jll.artifact_dir, "include", "xcb")
 xcb_util_keysims_dir = joinpath(Xorg_xcb_util_keysyms_jll.artifact_dir, "include", "xcb")
 xkb_include_dir = joinpath(xkbcommon_jll.artifact_dir, "include", "xkbcommon")
-xkb_headers = joinpath.(Ref(xkb_include_dir), ["xkbcommon.h"])
+xkb_headers = joinpath.(Ref(xkb_include_dir), ["xkbcommon.h", "xkbcommon-x11.h"])
 xcb_headers =  [joinpath(xcb_include_dir, "xcb.h"), joinpath(xcb_util_keysims_dir, "xcb_keysyms.h")]
 
 # Set up include paths

--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -1,36 +1,46 @@
 using Clang
 import Xorg_libxcb_jll
 import Xorg_xcb_util_keysyms_jll
+import xkbcommon_jll
 
 xcb_include_dir = joinpath(Xorg_libxcb_jll.artifact_dir, "include", "xcb")
 xcb_util_keysims_dir = joinpath(Xorg_xcb_util_keysyms_jll.artifact_dir, "include", "xcb")
-xcb_header =  [joinpath(xcb_include_dir, "xcb.h"), joinpath(xcb_util_keysims_dir, "xcb_keysyms.h")]
-
+xkb_include_dir = joinpath(xkbcommon_jll.artifact_dir, "include", "xkbcommon")
+xkb_headers = joinpath.(Ref(xkb_include_dir), ["xkbcommon.h"])
+xcb_headers =  [joinpath(xcb_include_dir, "xcb.h"), joinpath(xcb_util_keysims_dir, "xcb_keysyms.h")]
 
 # Set up include paths
-clang_includes = xcb_header
+clang_xcb_includes = [xcb_include_dir, xcb_util_keysims_dir]
+clang_xkb_includes = [xkb_include_dir]
 
 # Clang arguments
 clang_extraargs = ["-v"]
-# clang_extraargs = ["-D", "__STDC_LIMIT_MACROS", "-D", "__STDC_CONSTANT_MACROS"]
 
-# Callback to test if a header should actually be wrapped (for exclusion)
+# Test if a header should be wrapped
 function wrap_header(top_hdr, cursor_header)
-    return any(startswith.(Ref(dirname(cursor_header)), [xcb_include_dir, xcb_util_keysims_dir]))
+    any(startswith.(Ref(dirname(cursor_header)), [xcb_include_dir, xcb_util_keysims_dir, xkb_include_dir]))
 end
 
-function wrap_cursor(name, cursor)
-    return true
-end
-
-const wc = init(;
-                        headers=xcb_header,
+wc_xcb = init(;
+                        headers=xcb_headers,
                         output_file=joinpath(@__DIR__, "..", "gen", "xcb_api.jl"),
                         common_file=joinpath(@__DIR__, "..", "gen", "xcb_common.jl"),
-                        clang_includes=clang_includes,
+                        clang_includes=clang_xcb_includes,
                         clang_args=clang_extraargs,
                         header_wrapped=wrap_header,
                         header_library=x -> endswith(x, "xcb_keysyms.h") ? "libxcb_keysyms" : "libxcb",
-                        cursor_wrapped=wrap_cursor,
-                        clang_diagnostics=true)
-run(wc)
+                        clang_diagnostics=true,
+                        )
+run(wc_xcb)
+
+wc_xkb = init(;
+                        headers=xkb_headers,
+                        output_file=joinpath(@__DIR__, "..", "gen", "xkb_api.jl"),
+                        common_file=joinpath(@__DIR__, "..", "gen", "xkb_common.jl"),
+                        clang_includes=clang_xkb_includes,
+                        clang_args=clang_extraargs,
+                        header_wrapped=wrap_header,
+                        header_library=x -> "libxkbcommon",
+                        clang_diagnostics=true,
+                        )
+run(wc_xkb)

--- a/gen/xcb_api.jl
+++ b/gen/xcb_api.jl
@@ -1,4 +1,4 @@
-# Julia wrapper for header: xcb.h
+# Julia wrapper for header: xkb.h
 # Automatically generated using Clang.jl
 
 
@@ -2568,6 +2568,2002 @@ end
 
 function xcb_generate_id(c)
     ccall((:xcb_generate_id, libxcb), UInt32, (Ptr{xcb_connection_t},), c)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map(R)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map, libxcb_xkb), Ptr{xcb_xkb_get_kbd_by_name_replies_types_map_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), R)
+end
+
+function xcb_xkb_device_spec_next(i)
+    ccall((:xcb_xkb_device_spec_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_device_spec_iterator_t},), i)
+end
+
+function xcb_xkb_device_spec_end(i)
+    ccall((:xcb_xkb_device_spec_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_device_spec_iterator_t,), i)
+end
+
+function xcb_xkb_led_class_spec_next(i)
+    ccall((:xcb_xkb_led_class_spec_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_led_class_spec_iterator_t},), i)
+end
+
+function xcb_xkb_led_class_spec_end(i)
+    ccall((:xcb_xkb_led_class_spec_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_led_class_spec_iterator_t,), i)
+end
+
+function xcb_xkb_bell_class_spec_next(i)
+    ccall((:xcb_xkb_bell_class_spec_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_bell_class_spec_iterator_t},), i)
+end
+
+function xcb_xkb_bell_class_spec_end(i)
+    ccall((:xcb_xkb_bell_class_spec_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_bell_class_spec_iterator_t,), i)
+end
+
+function xcb_xkb_id_spec_next(i)
+    ccall((:xcb_xkb_id_spec_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_id_spec_iterator_t},), i)
+end
+
+function xcb_xkb_id_spec_end(i)
+    ccall((:xcb_xkb_id_spec_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_id_spec_iterator_t,), i)
+end
+
+function xcb_xkb_indicator_map_next(i)
+    ccall((:xcb_xkb_indicator_map_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_indicator_map_iterator_t},), i)
+end
+
+function xcb_xkb_indicator_map_end(i)
+    ccall((:xcb_xkb_indicator_map_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_indicator_map_iterator_t,), i)
+end
+
+function xcb_xkb_mod_def_next(i)
+    ccall((:xcb_xkb_mod_def_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_mod_def_iterator_t},), i)
+end
+
+function xcb_xkb_mod_def_end(i)
+    ccall((:xcb_xkb_mod_def_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_mod_def_iterator_t,), i)
+end
+
+function xcb_xkb_key_name_next(i)
+    ccall((:xcb_xkb_key_name_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_key_name_iterator_t},), i)
+end
+
+function xcb_xkb_key_name_end(i)
+    ccall((:xcb_xkb_key_name_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_key_name_iterator_t,), i)
+end
+
+function xcb_xkb_key_alias_next(i)
+    ccall((:xcb_xkb_key_alias_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_key_alias_iterator_t},), i)
+end
+
+function xcb_xkb_key_alias_end(i)
+    ccall((:xcb_xkb_key_alias_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_key_alias_iterator_t,), i)
+end
+
+function xcb_xkb_counted_string_16_sizeof(_buffer)
+    ccall((:xcb_xkb_counted_string_16_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_counted_string_16_string(R)
+    ccall((:xcb_xkb_counted_string_16_string, libxcb_xkb), Cstring, (Ptr{xcb_xkb_counted_string_16_t},), R)
+end
+
+function xcb_xkb_counted_string_16_string_length(R)
+    ccall((:xcb_xkb_counted_string_16_string_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_counted_string_16_t},), R)
+end
+
+function xcb_xkb_counted_string_16_string_end(R)
+    ccall((:xcb_xkb_counted_string_16_string_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_counted_string_16_t},), R)
+end
+
+function xcb_xkb_counted_string_16_alignment_pad(R)
+    ccall((:xcb_xkb_counted_string_16_alignment_pad, libxcb_xkb), Ptr{Cvoid}, (Ptr{xcb_xkb_counted_string_16_t},), R)
+end
+
+function xcb_xkb_counted_string_16_alignment_pad_length(R)
+    ccall((:xcb_xkb_counted_string_16_alignment_pad_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_counted_string_16_t},), R)
+end
+
+function xcb_xkb_counted_string_16_alignment_pad_end(R)
+    ccall((:xcb_xkb_counted_string_16_alignment_pad_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_counted_string_16_t},), R)
+end
+
+function xcb_xkb_counted_string_16_next(i)
+    ccall((:xcb_xkb_counted_string_16_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_counted_string_16_iterator_t},), i)
+end
+
+function xcb_xkb_counted_string_16_end(i)
+    ccall((:xcb_xkb_counted_string_16_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_counted_string_16_iterator_t,), i)
+end
+
+function xcb_xkb_kt_map_entry_next(i)
+    ccall((:xcb_xkb_kt_map_entry_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_kt_map_entry_iterator_t},), i)
+end
+
+function xcb_xkb_kt_map_entry_end(i)
+    ccall((:xcb_xkb_kt_map_entry_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_kt_map_entry_iterator_t,), i)
+end
+
+function xcb_xkb_key_type_sizeof(_buffer)
+    ccall((:xcb_xkb_key_type_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_key_type_map(R)
+    ccall((:xcb_xkb_key_type_map, libxcb_xkb), Ptr{xcb_xkb_kt_map_entry_t}, (Ptr{xcb_xkb_key_type_t},), R)
+end
+
+function xcb_xkb_key_type_map_length(R)
+    ccall((:xcb_xkb_key_type_map_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_key_type_t},), R)
+end
+
+function xcb_xkb_key_type_map_iterator(R)
+    ccall((:xcb_xkb_key_type_map_iterator, libxcb_xkb), xcb_xkb_kt_map_entry_iterator_t, (Ptr{xcb_xkb_key_type_t},), R)
+end
+
+function xcb_xkb_key_type_preserve(R)
+    ccall((:xcb_xkb_key_type_preserve, libxcb_xkb), Ptr{xcb_xkb_mod_def_t}, (Ptr{xcb_xkb_key_type_t},), R)
+end
+
+function xcb_xkb_key_type_preserve_length(R)
+    ccall((:xcb_xkb_key_type_preserve_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_key_type_t},), R)
+end
+
+function xcb_xkb_key_type_preserve_iterator(R)
+    ccall((:xcb_xkb_key_type_preserve_iterator, libxcb_xkb), xcb_xkb_mod_def_iterator_t, (Ptr{xcb_xkb_key_type_t},), R)
+end
+
+function xcb_xkb_key_type_next(i)
+    ccall((:xcb_xkb_key_type_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_key_type_iterator_t},), i)
+end
+
+function xcb_xkb_key_type_end(i)
+    ccall((:xcb_xkb_key_type_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_key_type_iterator_t,), i)
+end
+
+function xcb_xkb_key_sym_map_sizeof(_buffer)
+    ccall((:xcb_xkb_key_sym_map_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_key_sym_map_syms(R)
+    ccall((:xcb_xkb_key_sym_map_syms, libxcb_xkb), Ptr{xcb_keysym_t}, (Ptr{xcb_xkb_key_sym_map_t},), R)
+end
+
+function xcb_xkb_key_sym_map_syms_length(R)
+    ccall((:xcb_xkb_key_sym_map_syms_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_key_sym_map_t},), R)
+end
+
+function xcb_xkb_key_sym_map_syms_end(R)
+    ccall((:xcb_xkb_key_sym_map_syms_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_key_sym_map_t},), R)
+end
+
+function xcb_xkb_key_sym_map_next(i)
+    ccall((:xcb_xkb_key_sym_map_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_key_sym_map_iterator_t},), i)
+end
+
+function xcb_xkb_key_sym_map_end(i)
+    ccall((:xcb_xkb_key_sym_map_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_key_sym_map_iterator_t,), i)
+end
+
+function xcb_xkb_common_behavior_next(i)
+    ccall((:xcb_xkb_common_behavior_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_common_behavior_iterator_t},), i)
+end
+
+function xcb_xkb_common_behavior_end(i)
+    ccall((:xcb_xkb_common_behavior_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_common_behavior_iterator_t,), i)
+end
+
+function xcb_xkb_default_behavior_next(i)
+    ccall((:xcb_xkb_default_behavior_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_default_behavior_iterator_t},), i)
+end
+
+function xcb_xkb_default_behavior_end(i)
+    ccall((:xcb_xkb_default_behavior_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_default_behavior_iterator_t,), i)
+end
+
+function xcb_xkb_lock_behavior_next(i)
+    ccall((:xcb_xkb_lock_behavior_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_lock_behavior_iterator_t},), i)
+end
+
+function xcb_xkb_lock_behavior_end(i)
+    ccall((:xcb_xkb_lock_behavior_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_lock_behavior_iterator_t,), i)
+end
+
+function xcb_xkb_radio_group_behavior_next(i)
+    ccall((:xcb_xkb_radio_group_behavior_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_radio_group_behavior_iterator_t},), i)
+end
+
+function xcb_xkb_radio_group_behavior_end(i)
+    ccall((:xcb_xkb_radio_group_behavior_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_radio_group_behavior_iterator_t,), i)
+end
+
+function xcb_xkb_overlay_behavior_next(i)
+    ccall((:xcb_xkb_overlay_behavior_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_overlay_behavior_iterator_t},), i)
+end
+
+function xcb_xkb_overlay_behavior_end(i)
+    ccall((:xcb_xkb_overlay_behavior_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_overlay_behavior_iterator_t,), i)
+end
+
+function xcb_xkb_permament_lock_behavior_next(i)
+    ccall((:xcb_xkb_permament_lock_behavior_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_permament_lock_behavior_iterator_t},), i)
+end
+
+function xcb_xkb_permament_lock_behavior_end(i)
+    ccall((:xcb_xkb_permament_lock_behavior_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_permament_lock_behavior_iterator_t,), i)
+end
+
+function xcb_xkb_permament_radio_group_behavior_next(i)
+    ccall((:xcb_xkb_permament_radio_group_behavior_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_permament_radio_group_behavior_iterator_t},), i)
+end
+
+function xcb_xkb_permament_radio_group_behavior_end(i)
+    ccall((:xcb_xkb_permament_radio_group_behavior_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_permament_radio_group_behavior_iterator_t,), i)
+end
+
+function xcb_xkb_permament_overlay_behavior_next(i)
+    ccall((:xcb_xkb_permament_overlay_behavior_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_permament_overlay_behavior_iterator_t},), i)
+end
+
+function xcb_xkb_permament_overlay_behavior_end(i)
+    ccall((:xcb_xkb_permament_overlay_behavior_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_permament_overlay_behavior_iterator_t,), i)
+end
+
+function xcb_xkb_behavior_next(i)
+    ccall((:xcb_xkb_behavior_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_behavior_iterator_t},), i)
+end
+
+function xcb_xkb_behavior_end(i)
+    ccall((:xcb_xkb_behavior_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_behavior_iterator_t,), i)
+end
+
+function xcb_xkb_set_behavior_next(i)
+    ccall((:xcb_xkb_set_behavior_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_set_behavior_iterator_t},), i)
+end
+
+function xcb_xkb_set_behavior_end(i)
+    ccall((:xcb_xkb_set_behavior_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_set_behavior_iterator_t,), i)
+end
+
+function xcb_xkb_set_explicit_next(i)
+    ccall((:xcb_xkb_set_explicit_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_set_explicit_iterator_t},), i)
+end
+
+function xcb_xkb_set_explicit_end(i)
+    ccall((:xcb_xkb_set_explicit_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_set_explicit_iterator_t,), i)
+end
+
+function xcb_xkb_key_mod_map_next(i)
+    ccall((:xcb_xkb_key_mod_map_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_key_mod_map_iterator_t},), i)
+end
+
+function xcb_xkb_key_mod_map_end(i)
+    ccall((:xcb_xkb_key_mod_map_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_key_mod_map_iterator_t,), i)
+end
+
+function xcb_xkb_key_v_mod_map_next(i)
+    ccall((:xcb_xkb_key_v_mod_map_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_key_v_mod_map_iterator_t},), i)
+end
+
+function xcb_xkb_key_v_mod_map_end(i)
+    ccall((:xcb_xkb_key_v_mod_map_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_key_v_mod_map_iterator_t,), i)
+end
+
+function xcb_xkb_kt_set_map_entry_next(i)
+    ccall((:xcb_xkb_kt_set_map_entry_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_kt_set_map_entry_iterator_t},), i)
+end
+
+function xcb_xkb_kt_set_map_entry_end(i)
+    ccall((:xcb_xkb_kt_set_map_entry_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_kt_set_map_entry_iterator_t,), i)
+end
+
+function xcb_xkb_set_key_type_sizeof(_buffer)
+    ccall((:xcb_xkb_set_key_type_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_set_key_type_entries(R)
+    ccall((:xcb_xkb_set_key_type_entries, libxcb_xkb), Ptr{xcb_xkb_kt_set_map_entry_t}, (Ptr{xcb_xkb_set_key_type_t},), R)
+end
+
+function xcb_xkb_set_key_type_entries_length(R)
+    ccall((:xcb_xkb_set_key_type_entries_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_key_type_t},), R)
+end
+
+function xcb_xkb_set_key_type_entries_iterator(R)
+    ccall((:xcb_xkb_set_key_type_entries_iterator, libxcb_xkb), xcb_xkb_kt_set_map_entry_iterator_t, (Ptr{xcb_xkb_set_key_type_t},), R)
+end
+
+function xcb_xkb_set_key_type_preserve_entries(R)
+    ccall((:xcb_xkb_set_key_type_preserve_entries, libxcb_xkb), Ptr{xcb_xkb_kt_set_map_entry_t}, (Ptr{xcb_xkb_set_key_type_t},), R)
+end
+
+function xcb_xkb_set_key_type_preserve_entries_length(R)
+    ccall((:xcb_xkb_set_key_type_preserve_entries_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_key_type_t},), R)
+end
+
+function xcb_xkb_set_key_type_preserve_entries_iterator(R)
+    ccall((:xcb_xkb_set_key_type_preserve_entries_iterator, libxcb_xkb), xcb_xkb_kt_set_map_entry_iterator_t, (Ptr{xcb_xkb_set_key_type_t},), R)
+end
+
+function xcb_xkb_set_key_type_next(i)
+    ccall((:xcb_xkb_set_key_type_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_set_key_type_iterator_t},), i)
+end
+
+function xcb_xkb_set_key_type_end(i)
+    ccall((:xcb_xkb_set_key_type_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_set_key_type_iterator_t,), i)
+end
+
+function xcb_xkb_string8_next(i)
+    ccall((:xcb_xkb_string8_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_string8_iterator_t},), i)
+end
+
+function xcb_xkb_string8_end(i)
+    ccall((:xcb_xkb_string8_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_string8_iterator_t,), i)
+end
+
+function xcb_xkb_outline_sizeof(_buffer)
+    ccall((:xcb_xkb_outline_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_outline_points(R)
+    ccall((:xcb_xkb_outline_points, libxcb_xkb), Ptr{xcb_point_t}, (Ptr{xcb_xkb_outline_t},), R)
+end
+
+function xcb_xkb_outline_points_length(R)
+    ccall((:xcb_xkb_outline_points_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_outline_t},), R)
+end
+
+function xcb_xkb_outline_points_iterator(R)
+    ccall((:xcb_xkb_outline_points_iterator, libxcb_xkb), xcb_point_iterator_t, (Ptr{xcb_xkb_outline_t},), R)
+end
+
+function xcb_xkb_outline_next(i)
+    ccall((:xcb_xkb_outline_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_outline_iterator_t},), i)
+end
+
+function xcb_xkb_outline_end(i)
+    ccall((:xcb_xkb_outline_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_outline_iterator_t,), i)
+end
+
+function xcb_xkb_shape_sizeof(_buffer)
+    ccall((:xcb_xkb_shape_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_shape_outlines_length(R)
+    ccall((:xcb_xkb_shape_outlines_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_shape_t},), R)
+end
+
+function xcb_xkb_shape_outlines_iterator(R)
+    ccall((:xcb_xkb_shape_outlines_iterator, libxcb_xkb), xcb_xkb_outline_iterator_t, (Ptr{xcb_xkb_shape_t},), R)
+end
+
+function xcb_xkb_shape_next(i)
+    ccall((:xcb_xkb_shape_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_shape_iterator_t},), i)
+end
+
+function xcb_xkb_shape_end(i)
+    ccall((:xcb_xkb_shape_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_shape_iterator_t,), i)
+end
+
+function xcb_xkb_key_next(i)
+    ccall((:xcb_xkb_key_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_key_iterator_t},), i)
+end
+
+function xcb_xkb_key_end(i)
+    ccall((:xcb_xkb_key_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_key_iterator_t,), i)
+end
+
+function xcb_xkb_overlay_key_next(i)
+    ccall((:xcb_xkb_overlay_key_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_overlay_key_iterator_t},), i)
+end
+
+function xcb_xkb_overlay_key_end(i)
+    ccall((:xcb_xkb_overlay_key_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_overlay_key_iterator_t,), i)
+end
+
+function xcb_xkb_overlay_row_sizeof(_buffer)
+    ccall((:xcb_xkb_overlay_row_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_overlay_row_keys(R)
+    ccall((:xcb_xkb_overlay_row_keys, libxcb_xkb), Ptr{xcb_xkb_overlay_key_t}, (Ptr{xcb_xkb_overlay_row_t},), R)
+end
+
+function xcb_xkb_overlay_row_keys_length(R)
+    ccall((:xcb_xkb_overlay_row_keys_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_overlay_row_t},), R)
+end
+
+function xcb_xkb_overlay_row_keys_iterator(R)
+    ccall((:xcb_xkb_overlay_row_keys_iterator, libxcb_xkb), xcb_xkb_overlay_key_iterator_t, (Ptr{xcb_xkb_overlay_row_t},), R)
+end
+
+function xcb_xkb_overlay_row_next(i)
+    ccall((:xcb_xkb_overlay_row_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_overlay_row_iterator_t},), i)
+end
+
+function xcb_xkb_overlay_row_end(i)
+    ccall((:xcb_xkb_overlay_row_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_overlay_row_iterator_t,), i)
+end
+
+function xcb_xkb_overlay_sizeof(_buffer)
+    ccall((:xcb_xkb_overlay_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_overlay_rows_length(R)
+    ccall((:xcb_xkb_overlay_rows_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_overlay_t},), R)
+end
+
+function xcb_xkb_overlay_rows_iterator(R)
+    ccall((:xcb_xkb_overlay_rows_iterator, libxcb_xkb), xcb_xkb_overlay_row_iterator_t, (Ptr{xcb_xkb_overlay_t},), R)
+end
+
+function xcb_xkb_overlay_next(i)
+    ccall((:xcb_xkb_overlay_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_overlay_iterator_t},), i)
+end
+
+function xcb_xkb_overlay_end(i)
+    ccall((:xcb_xkb_overlay_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_overlay_iterator_t,), i)
+end
+
+function xcb_xkb_row_sizeof(_buffer)
+    ccall((:xcb_xkb_row_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_row_keys(R)
+    ccall((:xcb_xkb_row_keys, libxcb_xkb), Ptr{xcb_xkb_key_t}, (Ptr{xcb_xkb_row_t},), R)
+end
+
+function xcb_xkb_row_keys_length(R)
+    ccall((:xcb_xkb_row_keys_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_row_t},), R)
+end
+
+function xcb_xkb_row_keys_iterator(R)
+    ccall((:xcb_xkb_row_keys_iterator, libxcb_xkb), xcb_xkb_key_iterator_t, (Ptr{xcb_xkb_row_t},), R)
+end
+
+function xcb_xkb_row_next(i)
+    ccall((:xcb_xkb_row_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_row_iterator_t},), i)
+end
+
+function xcb_xkb_row_end(i)
+    ccall((:xcb_xkb_row_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_row_iterator_t,), i)
+end
+
+function xcb_xkb_listing_sizeof(_buffer)
+    ccall((:xcb_xkb_listing_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_listing_string(R)
+    ccall((:xcb_xkb_listing_string, libxcb_xkb), Ptr{xcb_xkb_string8_t}, (Ptr{xcb_xkb_listing_t},), R)
+end
+
+function xcb_xkb_listing_string_length(R)
+    ccall((:xcb_xkb_listing_string_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_listing_t},), R)
+end
+
+function xcb_xkb_listing_string_end(R)
+    ccall((:xcb_xkb_listing_string_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_listing_t},), R)
+end
+
+function xcb_xkb_listing_next(i)
+    ccall((:xcb_xkb_listing_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_listing_iterator_t},), i)
+end
+
+function xcb_xkb_listing_end(i)
+    ccall((:xcb_xkb_listing_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_listing_iterator_t,), i)
+end
+
+function xcb_xkb_device_led_info_sizeof(_buffer)
+    ccall((:xcb_xkb_device_led_info_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_device_led_info_names(R)
+    ccall((:xcb_xkb_device_led_info_names, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_device_led_info_t},), R)
+end
+
+function xcb_xkb_device_led_info_names_length(R)
+    ccall((:xcb_xkb_device_led_info_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_device_led_info_t},), R)
+end
+
+function xcb_xkb_device_led_info_names_end(R)
+    ccall((:xcb_xkb_device_led_info_names_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_device_led_info_t},), R)
+end
+
+function xcb_xkb_device_led_info_maps(R)
+    ccall((:xcb_xkb_device_led_info_maps, libxcb_xkb), Ptr{xcb_xkb_indicator_map_t}, (Ptr{xcb_xkb_device_led_info_t},), R)
+end
+
+function xcb_xkb_device_led_info_maps_length(R)
+    ccall((:xcb_xkb_device_led_info_maps_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_device_led_info_t},), R)
+end
+
+function xcb_xkb_device_led_info_maps_iterator(R)
+    ccall((:xcb_xkb_device_led_info_maps_iterator, libxcb_xkb), xcb_xkb_indicator_map_iterator_t, (Ptr{xcb_xkb_device_led_info_t},), R)
+end
+
+function xcb_xkb_device_led_info_next(i)
+    ccall((:xcb_xkb_device_led_info_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_device_led_info_iterator_t},), i)
+end
+
+function xcb_xkb_device_led_info_end(i)
+    ccall((:xcb_xkb_device_led_info_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_device_led_info_iterator_t,), i)
+end
+
+function xcb_xkb_sa_no_action_next(i)
+    ccall((:xcb_xkb_sa_no_action_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_no_action_iterator_t},), i)
+end
+
+function xcb_xkb_sa_no_action_end(i)
+    ccall((:xcb_xkb_sa_no_action_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_no_action_iterator_t,), i)
+end
+
+function xcb_xkb_sa_set_mods_next(i)
+    ccall((:xcb_xkb_sa_set_mods_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_set_mods_iterator_t},), i)
+end
+
+function xcb_xkb_sa_set_mods_end(i)
+    ccall((:xcb_xkb_sa_set_mods_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_set_mods_iterator_t,), i)
+end
+
+function xcb_xkb_sa_latch_mods_next(i)
+    ccall((:xcb_xkb_sa_latch_mods_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_latch_mods_iterator_t},), i)
+end
+
+function xcb_xkb_sa_latch_mods_end(i)
+    ccall((:xcb_xkb_sa_latch_mods_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_latch_mods_iterator_t,), i)
+end
+
+function xcb_xkb_sa_lock_mods_next(i)
+    ccall((:xcb_xkb_sa_lock_mods_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_lock_mods_iterator_t},), i)
+end
+
+function xcb_xkb_sa_lock_mods_end(i)
+    ccall((:xcb_xkb_sa_lock_mods_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_lock_mods_iterator_t,), i)
+end
+
+function xcb_xkb_sa_set_group_next(i)
+    ccall((:xcb_xkb_sa_set_group_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_set_group_iterator_t},), i)
+end
+
+function xcb_xkb_sa_set_group_end(i)
+    ccall((:xcb_xkb_sa_set_group_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_set_group_iterator_t,), i)
+end
+
+function xcb_xkb_sa_latch_group_next(i)
+    ccall((:xcb_xkb_sa_latch_group_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_latch_group_iterator_t},), i)
+end
+
+function xcb_xkb_sa_latch_group_end(i)
+    ccall((:xcb_xkb_sa_latch_group_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_latch_group_iterator_t,), i)
+end
+
+function xcb_xkb_sa_lock_group_next(i)
+    ccall((:xcb_xkb_sa_lock_group_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_lock_group_iterator_t},), i)
+end
+
+function xcb_xkb_sa_lock_group_end(i)
+    ccall((:xcb_xkb_sa_lock_group_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_lock_group_iterator_t,), i)
+end
+
+function xcb_xkb_sa_move_ptr_next(i)
+    ccall((:xcb_xkb_sa_move_ptr_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_move_ptr_iterator_t},), i)
+end
+
+function xcb_xkb_sa_move_ptr_end(i)
+    ccall((:xcb_xkb_sa_move_ptr_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_move_ptr_iterator_t,), i)
+end
+
+function xcb_xkb_sa_ptr_btn_next(i)
+    ccall((:xcb_xkb_sa_ptr_btn_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_ptr_btn_iterator_t},), i)
+end
+
+function xcb_xkb_sa_ptr_btn_end(i)
+    ccall((:xcb_xkb_sa_ptr_btn_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_ptr_btn_iterator_t,), i)
+end
+
+function xcb_xkb_sa_lock_ptr_btn_next(i)
+    ccall((:xcb_xkb_sa_lock_ptr_btn_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_lock_ptr_btn_iterator_t},), i)
+end
+
+function xcb_xkb_sa_lock_ptr_btn_end(i)
+    ccall((:xcb_xkb_sa_lock_ptr_btn_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_lock_ptr_btn_iterator_t,), i)
+end
+
+function xcb_xkb_sa_set_ptr_dflt_next(i)
+    ccall((:xcb_xkb_sa_set_ptr_dflt_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_set_ptr_dflt_iterator_t},), i)
+end
+
+function xcb_xkb_sa_set_ptr_dflt_end(i)
+    ccall((:xcb_xkb_sa_set_ptr_dflt_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_set_ptr_dflt_iterator_t,), i)
+end
+
+function xcb_xkb_sa_iso_lock_next(i)
+    ccall((:xcb_xkb_sa_iso_lock_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_iso_lock_iterator_t},), i)
+end
+
+function xcb_xkb_sa_iso_lock_end(i)
+    ccall((:xcb_xkb_sa_iso_lock_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_iso_lock_iterator_t,), i)
+end
+
+function xcb_xkb_sa_terminate_next(i)
+    ccall((:xcb_xkb_sa_terminate_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_terminate_iterator_t},), i)
+end
+
+function xcb_xkb_sa_terminate_end(i)
+    ccall((:xcb_xkb_sa_terminate_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_terminate_iterator_t,), i)
+end
+
+function xcb_xkb_sa_switch_screen_next(i)
+    ccall((:xcb_xkb_sa_switch_screen_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_switch_screen_iterator_t},), i)
+end
+
+function xcb_xkb_sa_switch_screen_end(i)
+    ccall((:xcb_xkb_sa_switch_screen_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_switch_screen_iterator_t,), i)
+end
+
+function xcb_xkb_sa_set_controls_next(i)
+    ccall((:xcb_xkb_sa_set_controls_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_set_controls_iterator_t},), i)
+end
+
+function xcb_xkb_sa_set_controls_end(i)
+    ccall((:xcb_xkb_sa_set_controls_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_set_controls_iterator_t,), i)
+end
+
+function xcb_xkb_sa_lock_controls_next(i)
+    ccall((:xcb_xkb_sa_lock_controls_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_lock_controls_iterator_t},), i)
+end
+
+function xcb_xkb_sa_lock_controls_end(i)
+    ccall((:xcb_xkb_sa_lock_controls_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_lock_controls_iterator_t,), i)
+end
+
+function xcb_xkb_sa_action_message_next(i)
+    ccall((:xcb_xkb_sa_action_message_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_action_message_iterator_t},), i)
+end
+
+function xcb_xkb_sa_action_message_end(i)
+    ccall((:xcb_xkb_sa_action_message_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_action_message_iterator_t,), i)
+end
+
+function xcb_xkb_sa_redirect_key_next(i)
+    ccall((:xcb_xkb_sa_redirect_key_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_redirect_key_iterator_t},), i)
+end
+
+function xcb_xkb_sa_redirect_key_end(i)
+    ccall((:xcb_xkb_sa_redirect_key_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_redirect_key_iterator_t,), i)
+end
+
+function xcb_xkb_sa_device_btn_next(i)
+    ccall((:xcb_xkb_sa_device_btn_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_device_btn_iterator_t},), i)
+end
+
+function xcb_xkb_sa_device_btn_end(i)
+    ccall((:xcb_xkb_sa_device_btn_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_device_btn_iterator_t,), i)
+end
+
+function xcb_xkb_sa_lock_device_btn_next(i)
+    ccall((:xcb_xkb_sa_lock_device_btn_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_lock_device_btn_iterator_t},), i)
+end
+
+function xcb_xkb_sa_lock_device_btn_end(i)
+    ccall((:xcb_xkb_sa_lock_device_btn_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_lock_device_btn_iterator_t,), i)
+end
+
+function xcb_xkb_sa_device_valuator_next(i)
+    ccall((:xcb_xkb_sa_device_valuator_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sa_device_valuator_iterator_t},), i)
+end
+
+function xcb_xkb_sa_device_valuator_end(i)
+    ccall((:xcb_xkb_sa_device_valuator_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sa_device_valuator_iterator_t,), i)
+end
+
+function xcb_xkb_si_action_next(i)
+    ccall((:xcb_xkb_si_action_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_si_action_iterator_t},), i)
+end
+
+function xcb_xkb_si_action_end(i)
+    ccall((:xcb_xkb_si_action_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_si_action_iterator_t,), i)
+end
+
+function xcb_xkb_sym_interpret_next(i)
+    ccall((:xcb_xkb_sym_interpret_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_sym_interpret_iterator_t},), i)
+end
+
+function xcb_xkb_sym_interpret_end(i)
+    ccall((:xcb_xkb_sym_interpret_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_sym_interpret_iterator_t,), i)
+end
+
+function xcb_xkb_action_next(i)
+    ccall((:xcb_xkb_action_next, libxcb_xkb), Cvoid, (Ptr{xcb_xkb_action_iterator_t},), i)
+end
+
+function xcb_xkb_action_end(i)
+    ccall((:xcb_xkb_action_end, libxcb_xkb), xcb_generic_iterator_t, (xcb_xkb_action_iterator_t,), i)
+end
+
+function xcb_xkb_use_extension(c, wantedMajor, wantedMinor)
+    ccall((:xcb_xkb_use_extension, libxcb_xkb), xcb_xkb_use_extension_cookie_t, (Ptr{xcb_connection_t}, UInt16, UInt16), c, wantedMajor, wantedMinor)
+end
+
+function xcb_xkb_use_extension_unchecked(c, wantedMajor, wantedMinor)
+    ccall((:xcb_xkb_use_extension_unchecked, libxcb_xkb), xcb_xkb_use_extension_cookie_t, (Ptr{xcb_connection_t}, UInt16, UInt16), c, wantedMajor, wantedMinor)
+end
+
+function xcb_xkb_use_extension_reply(c, cookie, e)
+    ccall((:xcb_xkb_use_extension_reply, libxcb_xkb), Ptr{xcb_xkb_use_extension_reply_t}, (Ptr{xcb_connection_t}, xcb_xkb_use_extension_cookie_t, Ptr{Ptr{xcb_generic_error_t}}), c, cookie, e)
+end
+
+function xcb_xkb_select_events_details_serialize(_buffer, affectWhich, clear, selectAll, _aux)
+    ccall((:xcb_xkb_select_events_details_serialize, libxcb_xkb), Cint, (Ptr{Ptr{Cvoid}}, UInt16, UInt16, UInt16, Ptr{xcb_xkb_select_events_details_t}), _buffer, affectWhich, clear, selectAll, _aux)
+end
+
+function xcb_xkb_select_events_details_unpack(_buffer, affectWhich, clear, selectAll, _aux)
+    ccall((:xcb_xkb_select_events_details_unpack, libxcb_xkb), Cint, (Ptr{Cvoid}, UInt16, UInt16, UInt16, Ptr{xcb_xkb_select_events_details_t}), _buffer, affectWhich, clear, selectAll, _aux)
+end
+
+function xcb_xkb_select_events_details_sizeof(_buffer, affectWhich, clear, selectAll)
+    ccall((:xcb_xkb_select_events_details_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid}, UInt16, UInt16, UInt16), _buffer, affectWhich, clear, selectAll)
+end
+
+function xcb_xkb_select_events_sizeof(_buffer)
+    ccall((:xcb_xkb_select_events_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_select_events_checked(c, deviceSpec, affectWhich, clear, selectAll, affectMap, map, details)
+    ccall((:xcb_xkb_select_events_checked, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt16, UInt16, UInt16, UInt16, Ptr{Cvoid}), c, deviceSpec, affectWhich, clear, selectAll, affectMap, map, details)
+end
+
+function xcb_xkb_select_events(c, deviceSpec, affectWhich, clear, selectAll, affectMap, map, details)
+    ccall((:xcb_xkb_select_events, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt16, UInt16, UInt16, UInt16, Ptr{Cvoid}), c, deviceSpec, affectWhich, clear, selectAll, affectMap, map, details)
+end
+
+function xcb_xkb_select_events_aux_checked(c, deviceSpec, affectWhich, clear, selectAll, affectMap, map, details)
+    ccall((:xcb_xkb_select_events_aux_checked, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt16, UInt16, UInt16, UInt16, Ptr{xcb_xkb_select_events_details_t}), c, deviceSpec, affectWhich, clear, selectAll, affectMap, map, details)
+end
+
+function xcb_xkb_select_events_aux(c, deviceSpec, affectWhich, clear, selectAll, affectMap, map, details)
+    ccall((:xcb_xkb_select_events_aux, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt16, UInt16, UInt16, UInt16, Ptr{xcb_xkb_select_events_details_t}), c, deviceSpec, affectWhich, clear, selectAll, affectMap, map, details)
+end
+
+function xcb_xkb_select_events_details(R)
+    ccall((:xcb_xkb_select_events_details, libxcb_xkb), Ptr{Cvoid}, (Ptr{xcb_xkb_select_events_request_t},), R)
+end
+
+function xcb_xkb_bell_checked(c, deviceSpec, bellClass, bellID, percent, forceSound, eventOnly, pitch, duration, name, window)
+    ccall((:xcb_xkb_bell_checked, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, xcb_xkb_bell_class_spec_t, xcb_xkb_id_spec_t, Int8, UInt8, UInt8, Int16, Int16, xcb_atom_t, xcb_window_t), c, deviceSpec, bellClass, bellID, percent, forceSound, eventOnly, pitch, duration, name, window)
+end
+
+function xcb_xkb_bell(c, deviceSpec, bellClass, bellID, percent, forceSound, eventOnly, pitch, duration, name, window)
+    ccall((:xcb_xkb_bell, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, xcb_xkb_bell_class_spec_t, xcb_xkb_id_spec_t, Int8, UInt8, UInt8, Int16, Int16, xcb_atom_t, xcb_window_t), c, deviceSpec, bellClass, bellID, percent, forceSound, eventOnly, pitch, duration, name, window)
+end
+
+function xcb_xkb_get_state(c, deviceSpec)
+    ccall((:xcb_xkb_get_state, libxcb_xkb), xcb_xkb_get_state_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t), c, deviceSpec)
+end
+
+function xcb_xkb_get_state_unchecked(c, deviceSpec)
+    ccall((:xcb_xkb_get_state_unchecked, libxcb_xkb), xcb_xkb_get_state_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t), c, deviceSpec)
+end
+
+function xcb_xkb_get_state_reply(c, cookie, e)
+    ccall((:xcb_xkb_get_state_reply, libxcb_xkb), Ptr{xcb_xkb_get_state_reply_t}, (Ptr{xcb_connection_t}, xcb_xkb_get_state_cookie_t, Ptr{Ptr{xcb_generic_error_t}}), c, cookie, e)
+end
+
+function xcb_xkb_latch_lock_state_checked(c, deviceSpec, affectModLocks, modLocks, lockGroup, groupLock, affectModLatches, latchGroup, groupLatch)
+    ccall((:xcb_xkb_latch_lock_state_checked, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt16), c, deviceSpec, affectModLocks, modLocks, lockGroup, groupLock, affectModLatches, latchGroup, groupLatch)
+end
+
+function xcb_xkb_latch_lock_state(c, deviceSpec, affectModLocks, modLocks, lockGroup, groupLock, affectModLatches, latchGroup, groupLatch)
+    ccall((:xcb_xkb_latch_lock_state, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt16), c, deviceSpec, affectModLocks, modLocks, lockGroup, groupLock, affectModLatches, latchGroup, groupLatch)
+end
+
+function xcb_xkb_get_controls(c, deviceSpec)
+    ccall((:xcb_xkb_get_controls, libxcb_xkb), xcb_xkb_get_controls_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t), c, deviceSpec)
+end
+
+function xcb_xkb_get_controls_unchecked(c, deviceSpec)
+    ccall((:xcb_xkb_get_controls_unchecked, libxcb_xkb), xcb_xkb_get_controls_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t), c, deviceSpec)
+end
+
+function xcb_xkb_get_controls_reply(c, cookie, e)
+    ccall((:xcb_xkb_get_controls_reply, libxcb_xkb), Ptr{xcb_xkb_get_controls_reply_t}, (Ptr{xcb_connection_t}, xcb_xkb_get_controls_cookie_t, Ptr{Ptr{xcb_generic_error_t}}), c, cookie, e)
+end
+
+function xcb_xkb_set_controls_checked(c, deviceSpec, affectInternalRealMods, internalRealMods, affectIgnoreLockRealMods, ignoreLockRealMods, affectInternalVirtualMods, internalVirtualMods, affectIgnoreLockVirtualMods, ignoreLockVirtualMods, mouseKeysDfltBtn, groupsWrap, accessXOptions, affectEnabledControls, enabledControls, changeControls, repeatDelay, repeatInterval, slowKeysDelay, debounceDelay, mouseKeysDelay, mouseKeysInterval, mouseKeysTimeToMax, mouseKeysMaxSpeed, mouseKeysCurve, accessXTimeout, accessXTimeoutMask, accessXTimeoutValues, accessXTimeoutOptionsMask, accessXTimeoutOptionsValues, perKeyRepeat)
+    ccall((:xcb_xkb_set_controls_checked, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt8, UInt8, UInt8, UInt8, UInt16, UInt16, UInt16, UInt16, UInt8, UInt8, UInt16, UInt32, UInt32, UInt32, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, Int16, UInt16, UInt32, UInt32, UInt16, UInt16, Ptr{UInt8}), c, deviceSpec, affectInternalRealMods, internalRealMods, affectIgnoreLockRealMods, ignoreLockRealMods, affectInternalVirtualMods, internalVirtualMods, affectIgnoreLockVirtualMods, ignoreLockVirtualMods, mouseKeysDfltBtn, groupsWrap, accessXOptions, affectEnabledControls, enabledControls, changeControls, repeatDelay, repeatInterval, slowKeysDelay, debounceDelay, mouseKeysDelay, mouseKeysInterval, mouseKeysTimeToMax, mouseKeysMaxSpeed, mouseKeysCurve, accessXTimeout, accessXTimeoutMask, accessXTimeoutValues, accessXTimeoutOptionsMask, accessXTimeoutOptionsValues, perKeyRepeat)
+end
+
+function xcb_xkb_set_controls(c, deviceSpec, affectInternalRealMods, internalRealMods, affectIgnoreLockRealMods, ignoreLockRealMods, affectInternalVirtualMods, internalVirtualMods, affectIgnoreLockVirtualMods, ignoreLockVirtualMods, mouseKeysDfltBtn, groupsWrap, accessXOptions, affectEnabledControls, enabledControls, changeControls, repeatDelay, repeatInterval, slowKeysDelay, debounceDelay, mouseKeysDelay, mouseKeysInterval, mouseKeysTimeToMax, mouseKeysMaxSpeed, mouseKeysCurve, accessXTimeout, accessXTimeoutMask, accessXTimeoutValues, accessXTimeoutOptionsMask, accessXTimeoutOptionsValues, perKeyRepeat)
+    ccall((:xcb_xkb_set_controls, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt8, UInt8, UInt8, UInt8, UInt16, UInt16, UInt16, UInt16, UInt8, UInt8, UInt16, UInt32, UInt32, UInt32, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, Int16, UInt16, UInt32, UInt32, UInt16, UInt16, Ptr{UInt8}), c, deviceSpec, affectInternalRealMods, internalRealMods, affectIgnoreLockRealMods, ignoreLockRealMods, affectInternalVirtualMods, internalVirtualMods, affectIgnoreLockVirtualMods, ignoreLockVirtualMods, mouseKeysDfltBtn, groupsWrap, accessXOptions, affectEnabledControls, enabledControls, changeControls, repeatDelay, repeatInterval, slowKeysDelay, debounceDelay, mouseKeysDelay, mouseKeysInterval, mouseKeysTimeToMax, mouseKeysMaxSpeed, mouseKeysCurve, accessXTimeout, accessXTimeoutMask, accessXTimeoutValues, accessXTimeoutOptionsMask, accessXTimeoutOptionsValues, perKeyRepeat)
+end
+
+function xcb_xkb_get_map_map_types_rtrn_length(R, S)
+    ccall((:xcb_xkb_get_map_map_types_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_types_rtrn_iterator(R, S)
+    ccall((:xcb_xkb_get_map_map_types_rtrn_iterator, libxcb_xkb), xcb_xkb_key_type_iterator_t, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_syms_rtrn_length(R, S)
+    ccall((:xcb_xkb_get_map_map_syms_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_syms_rtrn_iterator(R, S)
+    ccall((:xcb_xkb_get_map_map_syms_rtrn_iterator, libxcb_xkb), xcb_xkb_key_sym_map_iterator_t, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_acts_rtrn_count(S)
+    ccall((:xcb_xkb_get_map_map_acts_rtrn_count, libxcb_xkb), Ptr{UInt8}, (Ptr{xcb_xkb_get_map_map_t},), S)
+end
+
+function xcb_xkb_get_map_map_acts_rtrn_count_length(R, S)
+    ccall((:xcb_xkb_get_map_map_acts_rtrn_count_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_acts_rtrn_count_end(R, S)
+    ccall((:xcb_xkb_get_map_map_acts_rtrn_count_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_acts_rtrn_acts(S)
+    ccall((:xcb_xkb_get_map_map_acts_rtrn_acts, libxcb_xkb), Ptr{xcb_xkb_action_t}, (Ptr{xcb_xkb_get_map_map_t},), S)
+end
+
+function xcb_xkb_get_map_map_acts_rtrn_acts_length(R, S)
+    ccall((:xcb_xkb_get_map_map_acts_rtrn_acts_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_acts_rtrn_acts_iterator(R, S)
+    ccall((:xcb_xkb_get_map_map_acts_rtrn_acts_iterator, libxcb_xkb), xcb_xkb_action_iterator_t, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_behaviors_rtrn(S)
+    ccall((:xcb_xkb_get_map_map_behaviors_rtrn, libxcb_xkb), Ptr{xcb_xkb_set_behavior_t}, (Ptr{xcb_xkb_get_map_map_t},), S)
+end
+
+function xcb_xkb_get_map_map_behaviors_rtrn_length(R, S)
+    ccall((:xcb_xkb_get_map_map_behaviors_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_behaviors_rtrn_iterator(R, S)
+    ccall((:xcb_xkb_get_map_map_behaviors_rtrn_iterator, libxcb_xkb), xcb_xkb_set_behavior_iterator_t, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_vmods_rtrn(S)
+    ccall((:xcb_xkb_get_map_map_vmods_rtrn, libxcb_xkb), Ptr{UInt8}, (Ptr{xcb_xkb_get_map_map_t},), S)
+end
+
+function xcb_xkb_get_map_map_vmods_rtrn_length(R, S)
+    ccall((:xcb_xkb_get_map_map_vmods_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_vmods_rtrn_end(R, S)
+    ccall((:xcb_xkb_get_map_map_vmods_rtrn_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_explicit_rtrn(S)
+    ccall((:xcb_xkb_get_map_map_explicit_rtrn, libxcb_xkb), Ptr{xcb_xkb_set_explicit_t}, (Ptr{xcb_xkb_get_map_map_t},), S)
+end
+
+function xcb_xkb_get_map_map_explicit_rtrn_length(R, S)
+    ccall((:xcb_xkb_get_map_map_explicit_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_explicit_rtrn_iterator(R, S)
+    ccall((:xcb_xkb_get_map_map_explicit_rtrn_iterator, libxcb_xkb), xcb_xkb_set_explicit_iterator_t, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_modmap_rtrn(S)
+    ccall((:xcb_xkb_get_map_map_modmap_rtrn, libxcb_xkb), Ptr{xcb_xkb_key_mod_map_t}, (Ptr{xcb_xkb_get_map_map_t},), S)
+end
+
+function xcb_xkb_get_map_map_modmap_rtrn_length(R, S)
+    ccall((:xcb_xkb_get_map_map_modmap_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_modmap_rtrn_iterator(R, S)
+    ccall((:xcb_xkb_get_map_map_modmap_rtrn_iterator, libxcb_xkb), xcb_xkb_key_mod_map_iterator_t, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_vmodmap_rtrn(S)
+    ccall((:xcb_xkb_get_map_map_vmodmap_rtrn, libxcb_xkb), Ptr{xcb_xkb_key_v_mod_map_t}, (Ptr{xcb_xkb_get_map_map_t},), S)
+end
+
+function xcb_xkb_get_map_map_vmodmap_rtrn_length(R, S)
+    ccall((:xcb_xkb_get_map_map_vmodmap_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_vmodmap_rtrn_iterator(R, S)
+    ccall((:xcb_xkb_get_map_map_vmodmap_rtrn_iterator, libxcb_xkb), xcb_xkb_key_v_mod_map_iterator_t, (Ptr{xcb_xkb_get_map_reply_t}, Ptr{xcb_xkb_get_map_map_t}), R, S)
+end
+
+function xcb_xkb_get_map_map_serialize(_buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present, _aux)
+    ccall((:xcb_xkb_get_map_map_serialize, libxcb_xkb), Cint, (Ptr{Ptr{Cvoid}}, UInt8, UInt8, UInt8, UInt16, UInt8, UInt16, UInt8, UInt8, UInt8, UInt16, Ptr{xcb_xkb_get_map_map_t}), _buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present, _aux)
+end
+
+function xcb_xkb_get_map_map_unpack(_buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present, _aux)
+    ccall((:xcb_xkb_get_map_map_unpack, libxcb_xkb), Cint, (Ptr{Cvoid}, UInt8, UInt8, UInt8, UInt16, UInt8, UInt16, UInt8, UInt8, UInt8, UInt16, Ptr{xcb_xkb_get_map_map_t}), _buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present, _aux)
+end
+
+function xcb_xkb_get_map_map_sizeof(_buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present)
+    ccall((:xcb_xkb_get_map_map_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid}, UInt8, UInt8, UInt8, UInt16, UInt8, UInt16, UInt8, UInt8, UInt8, UInt16), _buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present)
+end
+
+function xcb_xkb_get_map_sizeof(_buffer)
+    ccall((:xcb_xkb_get_map_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_get_map(c, deviceSpec, full, partial, firstType, nTypes, firstKeySym, nKeySyms, firstKeyAction, nKeyActions, firstKeyBehavior, nKeyBehaviors, virtualMods, firstKeyExplicit, nKeyExplicit, firstModMapKey, nModMapKeys, firstVModMapKey, nVModMapKeys)
+    ccall((:xcb_xkb_get_map, libxcb_xkb), xcb_xkb_get_map_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt16, UInt8, UInt8, xcb_keycode_t, UInt8, xcb_keycode_t, UInt8, xcb_keycode_t, UInt8, UInt16, xcb_keycode_t, UInt8, xcb_keycode_t, UInt8, xcb_keycode_t, UInt8), c, deviceSpec, full, partial, firstType, nTypes, firstKeySym, nKeySyms, firstKeyAction, nKeyActions, firstKeyBehavior, nKeyBehaviors, virtualMods, firstKeyExplicit, nKeyExplicit, firstModMapKey, nModMapKeys, firstVModMapKey, nVModMapKeys)
+end
+
+function xcb_xkb_get_map_unchecked(c, deviceSpec, full, partial, firstType, nTypes, firstKeySym, nKeySyms, firstKeyAction, nKeyActions, firstKeyBehavior, nKeyBehaviors, virtualMods, firstKeyExplicit, nKeyExplicit, firstModMapKey, nModMapKeys, firstVModMapKey, nVModMapKeys)
+    ccall((:xcb_xkb_get_map_unchecked, libxcb_xkb), xcb_xkb_get_map_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt16, UInt8, UInt8, xcb_keycode_t, UInt8, xcb_keycode_t, UInt8, xcb_keycode_t, UInt8, UInt16, xcb_keycode_t, UInt8, xcb_keycode_t, UInt8, xcb_keycode_t, UInt8), c, deviceSpec, full, partial, firstType, nTypes, firstKeySym, nKeySyms, firstKeyAction, nKeyActions, firstKeyBehavior, nKeyBehaviors, virtualMods, firstKeyExplicit, nKeyExplicit, firstModMapKey, nModMapKeys, firstVModMapKey, nVModMapKeys)
+end
+
+function xcb_xkb_get_map_map(R)
+    ccall((:xcb_xkb_get_map_map, libxcb_xkb), Ptr{Cvoid}, (Ptr{xcb_xkb_get_map_reply_t},), R)
+end
+
+function xcb_xkb_get_map_reply(c, cookie, e)
+    ccall((:xcb_xkb_get_map_reply, libxcb_xkb), Ptr{xcb_xkb_get_map_reply_t}, (Ptr{xcb_connection_t}, xcb_xkb_get_map_cookie_t, Ptr{Ptr{xcb_generic_error_t}}), c, cookie, e)
+end
+
+function xcb_xkb_set_map_values_types_length(R, S)
+    ccall((:xcb_xkb_set_map_values_types_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_types_iterator(R, S)
+    ccall((:xcb_xkb_set_map_values_types_iterator, libxcb_xkb), xcb_xkb_set_key_type_iterator_t, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_syms_length(R, S)
+    ccall((:xcb_xkb_set_map_values_syms_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_syms_iterator(R, S)
+    ccall((:xcb_xkb_set_map_values_syms_iterator, libxcb_xkb), xcb_xkb_key_sym_map_iterator_t, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_actions_count(S)
+    ccall((:xcb_xkb_set_map_values_actions_count, libxcb_xkb), Ptr{UInt8}, (Ptr{xcb_xkb_set_map_values_t},), S)
+end
+
+function xcb_xkb_set_map_values_actions_count_length(R, S)
+    ccall((:xcb_xkb_set_map_values_actions_count_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_actions_count_end(R, S)
+    ccall((:xcb_xkb_set_map_values_actions_count_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_actions(S)
+    ccall((:xcb_xkb_set_map_values_actions, libxcb_xkb), Ptr{xcb_xkb_action_t}, (Ptr{xcb_xkb_set_map_values_t},), S)
+end
+
+function xcb_xkb_set_map_values_actions_length(R, S)
+    ccall((:xcb_xkb_set_map_values_actions_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_actions_iterator(R, S)
+    ccall((:xcb_xkb_set_map_values_actions_iterator, libxcb_xkb), xcb_xkb_action_iterator_t, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_behaviors(S)
+    ccall((:xcb_xkb_set_map_values_behaviors, libxcb_xkb), Ptr{xcb_xkb_set_behavior_t}, (Ptr{xcb_xkb_set_map_values_t},), S)
+end
+
+function xcb_xkb_set_map_values_behaviors_length(R, S)
+    ccall((:xcb_xkb_set_map_values_behaviors_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_behaviors_iterator(R, S)
+    ccall((:xcb_xkb_set_map_values_behaviors_iterator, libxcb_xkb), xcb_xkb_set_behavior_iterator_t, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_vmods(S)
+    ccall((:xcb_xkb_set_map_values_vmods, libxcb_xkb), Ptr{UInt8}, (Ptr{xcb_xkb_set_map_values_t},), S)
+end
+
+function xcb_xkb_set_map_values_vmods_length(R, S)
+    ccall((:xcb_xkb_set_map_values_vmods_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_vmods_end(R, S)
+    ccall((:xcb_xkb_set_map_values_vmods_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_explicit(S)
+    ccall((:xcb_xkb_set_map_values_explicit, libxcb_xkb), Ptr{xcb_xkb_set_explicit_t}, (Ptr{xcb_xkb_set_map_values_t},), S)
+end
+
+function xcb_xkb_set_map_values_explicit_length(R, S)
+    ccall((:xcb_xkb_set_map_values_explicit_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_explicit_iterator(R, S)
+    ccall((:xcb_xkb_set_map_values_explicit_iterator, libxcb_xkb), xcb_xkb_set_explicit_iterator_t, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_modmap(S)
+    ccall((:xcb_xkb_set_map_values_modmap, libxcb_xkb), Ptr{xcb_xkb_key_mod_map_t}, (Ptr{xcb_xkb_set_map_values_t},), S)
+end
+
+function xcb_xkb_set_map_values_modmap_length(R, S)
+    ccall((:xcb_xkb_set_map_values_modmap_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_modmap_iterator(R, S)
+    ccall((:xcb_xkb_set_map_values_modmap_iterator, libxcb_xkb), xcb_xkb_key_mod_map_iterator_t, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_vmodmap(S)
+    ccall((:xcb_xkb_set_map_values_vmodmap, libxcb_xkb), Ptr{xcb_xkb_key_v_mod_map_t}, (Ptr{xcb_xkb_set_map_values_t},), S)
+end
+
+function xcb_xkb_set_map_values_vmodmap_length(R, S)
+    ccall((:xcb_xkb_set_map_values_vmodmap_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_vmodmap_iterator(R, S)
+    ccall((:xcb_xkb_set_map_values_vmodmap_iterator, libxcb_xkb), xcb_xkb_key_v_mod_map_iterator_t, (Ptr{xcb_xkb_set_map_request_t}, Ptr{xcb_xkb_set_map_values_t}), R, S)
+end
+
+function xcb_xkb_set_map_values_serialize(_buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present, _aux)
+    ccall((:xcb_xkb_set_map_values_serialize, libxcb_xkb), Cint, (Ptr{Ptr{Cvoid}}, UInt8, UInt8, UInt8, UInt16, UInt8, UInt16, UInt8, UInt8, UInt8, UInt16, Ptr{xcb_xkb_set_map_values_t}), _buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present, _aux)
+end
+
+function xcb_xkb_set_map_values_unpack(_buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present, _aux)
+    ccall((:xcb_xkb_set_map_values_unpack, libxcb_xkb), Cint, (Ptr{Cvoid}, UInt8, UInt8, UInt8, UInt16, UInt8, UInt16, UInt8, UInt8, UInt8, UInt16, Ptr{xcb_xkb_set_map_values_t}), _buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present, _aux)
+end
+
+function xcb_xkb_set_map_values_sizeof(_buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present)
+    ccall((:xcb_xkb_set_map_values_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid}, UInt8, UInt8, UInt8, UInt16, UInt8, UInt16, UInt8, UInt8, UInt8, UInt16), _buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present)
+end
+
+function xcb_xkb_set_map_sizeof(_buffer)
+    ccall((:xcb_xkb_set_map_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_set_map_checked(c, deviceSpec, present, flags, minKeyCode, maxKeyCode, firstType, nTypes, firstKeySym, nKeySyms, totalSyms, firstKeyAction, nKeyActions, totalActions, firstKeyBehavior, nKeyBehaviors, totalKeyBehaviors, firstKeyExplicit, nKeyExplicit, totalKeyExplicit, firstModMapKey, nModMapKeys, totalModMapKeys, firstVModMapKey, nVModMapKeys, totalVModMapKeys, virtualMods, values)
+    ccall((:xcb_xkb_set_map_checked, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt16, xcb_keycode_t, xcb_keycode_t, UInt8, UInt8, xcb_keycode_t, UInt8, UInt16, xcb_keycode_t, UInt8, UInt16, xcb_keycode_t, UInt8, UInt8, xcb_keycode_t, UInt8, UInt8, xcb_keycode_t, UInt8, UInt8, xcb_keycode_t, UInt8, UInt8, UInt16, Ptr{Cvoid}), c, deviceSpec, present, flags, minKeyCode, maxKeyCode, firstType, nTypes, firstKeySym, nKeySyms, totalSyms, firstKeyAction, nKeyActions, totalActions, firstKeyBehavior, nKeyBehaviors, totalKeyBehaviors, firstKeyExplicit, nKeyExplicit, totalKeyExplicit, firstModMapKey, nModMapKeys, totalModMapKeys, firstVModMapKey, nVModMapKeys, totalVModMapKeys, virtualMods, values)
+end
+
+function xcb_xkb_set_map(c, deviceSpec, present, flags, minKeyCode, maxKeyCode, firstType, nTypes, firstKeySym, nKeySyms, totalSyms, firstKeyAction, nKeyActions, totalActions, firstKeyBehavior, nKeyBehaviors, totalKeyBehaviors, firstKeyExplicit, nKeyExplicit, totalKeyExplicit, firstModMapKey, nModMapKeys, totalModMapKeys, firstVModMapKey, nVModMapKeys, totalVModMapKeys, virtualMods, values)
+    ccall((:xcb_xkb_set_map, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt16, xcb_keycode_t, xcb_keycode_t, UInt8, UInt8, xcb_keycode_t, UInt8, UInt16, xcb_keycode_t, UInt8, UInt16, xcb_keycode_t, UInt8, UInt8, xcb_keycode_t, UInt8, UInt8, xcb_keycode_t, UInt8, UInt8, xcb_keycode_t, UInt8, UInt8, UInt16, Ptr{Cvoid}), c, deviceSpec, present, flags, minKeyCode, maxKeyCode, firstType, nTypes, firstKeySym, nKeySyms, totalSyms, firstKeyAction, nKeyActions, totalActions, firstKeyBehavior, nKeyBehaviors, totalKeyBehaviors, firstKeyExplicit, nKeyExplicit, totalKeyExplicit, firstModMapKey, nModMapKeys, totalModMapKeys, firstVModMapKey, nVModMapKeys, totalVModMapKeys, virtualMods, values)
+end
+
+function xcb_xkb_set_map_aux_checked(c, deviceSpec, present, flags, minKeyCode, maxKeyCode, firstType, nTypes, firstKeySym, nKeySyms, totalSyms, firstKeyAction, nKeyActions, totalActions, firstKeyBehavior, nKeyBehaviors, totalKeyBehaviors, firstKeyExplicit, nKeyExplicit, totalKeyExplicit, firstModMapKey, nModMapKeys, totalModMapKeys, firstVModMapKey, nVModMapKeys, totalVModMapKeys, virtualMods, values)
+    ccall((:xcb_xkb_set_map_aux_checked, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt16, xcb_keycode_t, xcb_keycode_t, UInt8, UInt8, xcb_keycode_t, UInt8, UInt16, xcb_keycode_t, UInt8, UInt16, xcb_keycode_t, UInt8, UInt8, xcb_keycode_t, UInt8, UInt8, xcb_keycode_t, UInt8, UInt8, xcb_keycode_t, UInt8, UInt8, UInt16, Ptr{xcb_xkb_set_map_values_t}), c, deviceSpec, present, flags, minKeyCode, maxKeyCode, firstType, nTypes, firstKeySym, nKeySyms, totalSyms, firstKeyAction, nKeyActions, totalActions, firstKeyBehavior, nKeyBehaviors, totalKeyBehaviors, firstKeyExplicit, nKeyExplicit, totalKeyExplicit, firstModMapKey, nModMapKeys, totalModMapKeys, firstVModMapKey, nVModMapKeys, totalVModMapKeys, virtualMods, values)
+end
+
+function xcb_xkb_set_map_aux(c, deviceSpec, present, flags, minKeyCode, maxKeyCode, firstType, nTypes, firstKeySym, nKeySyms, totalSyms, firstKeyAction, nKeyActions, totalActions, firstKeyBehavior, nKeyBehaviors, totalKeyBehaviors, firstKeyExplicit, nKeyExplicit, totalKeyExplicit, firstModMapKey, nModMapKeys, totalModMapKeys, firstVModMapKey, nVModMapKeys, totalVModMapKeys, virtualMods, values)
+    ccall((:xcb_xkb_set_map_aux, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt16, xcb_keycode_t, xcb_keycode_t, UInt8, UInt8, xcb_keycode_t, UInt8, UInt16, xcb_keycode_t, UInt8, UInt16, xcb_keycode_t, UInt8, UInt8, xcb_keycode_t, UInt8, UInt8, xcb_keycode_t, UInt8, UInt8, xcb_keycode_t, UInt8, UInt8, UInt16, Ptr{xcb_xkb_set_map_values_t}), c, deviceSpec, present, flags, minKeyCode, maxKeyCode, firstType, nTypes, firstKeySym, nKeySyms, totalSyms, firstKeyAction, nKeyActions, totalActions, firstKeyBehavior, nKeyBehaviors, totalKeyBehaviors, firstKeyExplicit, nKeyExplicit, totalKeyExplicit, firstModMapKey, nModMapKeys, totalModMapKeys, firstVModMapKey, nVModMapKeys, totalVModMapKeys, virtualMods, values)
+end
+
+function xcb_xkb_set_map_values(R)
+    ccall((:xcb_xkb_set_map_values, libxcb_xkb), Ptr{Cvoid}, (Ptr{xcb_xkb_set_map_request_t},), R)
+end
+
+function xcb_xkb_get_compat_map_sizeof(_buffer)
+    ccall((:xcb_xkb_get_compat_map_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_get_compat_map(c, deviceSpec, groups, getAllSI, firstSI, nSI)
+    ccall((:xcb_xkb_get_compat_map, libxcb_xkb), xcb_xkb_get_compat_map_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt8, UInt8, UInt16, UInt16), c, deviceSpec, groups, getAllSI, firstSI, nSI)
+end
+
+function xcb_xkb_get_compat_map_unchecked(c, deviceSpec, groups, getAllSI, firstSI, nSI)
+    ccall((:xcb_xkb_get_compat_map_unchecked, libxcb_xkb), xcb_xkb_get_compat_map_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt8, UInt8, UInt16, UInt16), c, deviceSpec, groups, getAllSI, firstSI, nSI)
+end
+
+function xcb_xkb_get_compat_map_si_rtrn(R)
+    ccall((:xcb_xkb_get_compat_map_si_rtrn, libxcb_xkb), Ptr{xcb_xkb_sym_interpret_t}, (Ptr{xcb_xkb_get_compat_map_reply_t},), R)
+end
+
+function xcb_xkb_get_compat_map_si_rtrn_length(R)
+    ccall((:xcb_xkb_get_compat_map_si_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_compat_map_reply_t},), R)
+end
+
+function xcb_xkb_get_compat_map_si_rtrn_iterator(R)
+    ccall((:xcb_xkb_get_compat_map_si_rtrn_iterator, libxcb_xkb), xcb_xkb_sym_interpret_iterator_t, (Ptr{xcb_xkb_get_compat_map_reply_t},), R)
+end
+
+function xcb_xkb_get_compat_map_group_rtrn(R)
+    ccall((:xcb_xkb_get_compat_map_group_rtrn, libxcb_xkb), Ptr{xcb_xkb_mod_def_t}, (Ptr{xcb_xkb_get_compat_map_reply_t},), R)
+end
+
+function xcb_xkb_get_compat_map_group_rtrn_length(R)
+    ccall((:xcb_xkb_get_compat_map_group_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_compat_map_reply_t},), R)
+end
+
+function xcb_xkb_get_compat_map_group_rtrn_iterator(R)
+    ccall((:xcb_xkb_get_compat_map_group_rtrn_iterator, libxcb_xkb), xcb_xkb_mod_def_iterator_t, (Ptr{xcb_xkb_get_compat_map_reply_t},), R)
+end
+
+function xcb_xkb_get_compat_map_reply(c, cookie, e)
+    ccall((:xcb_xkb_get_compat_map_reply, libxcb_xkb), Ptr{xcb_xkb_get_compat_map_reply_t}, (Ptr{xcb_connection_t}, xcb_xkb_get_compat_map_cookie_t, Ptr{Ptr{xcb_generic_error_t}}), c, cookie, e)
+end
+
+function xcb_xkb_set_compat_map_sizeof(_buffer)
+    ccall((:xcb_xkb_set_compat_map_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_set_compat_map_checked(c, deviceSpec, recomputeActions, truncateSI, groups, firstSI, nSI, si, groupMaps)
+    ccall((:xcb_xkb_set_compat_map_checked, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt8, UInt8, UInt8, UInt16, UInt16, Ptr{xcb_xkb_sym_interpret_t}, Ptr{xcb_xkb_mod_def_t}), c, deviceSpec, recomputeActions, truncateSI, groups, firstSI, nSI, si, groupMaps)
+end
+
+function xcb_xkb_set_compat_map(c, deviceSpec, recomputeActions, truncateSI, groups, firstSI, nSI, si, groupMaps)
+    ccall((:xcb_xkb_set_compat_map, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt8, UInt8, UInt8, UInt16, UInt16, Ptr{xcb_xkb_sym_interpret_t}, Ptr{xcb_xkb_mod_def_t}), c, deviceSpec, recomputeActions, truncateSI, groups, firstSI, nSI, si, groupMaps)
+end
+
+function xcb_xkb_set_compat_map_si(R)
+    ccall((:xcb_xkb_set_compat_map_si, libxcb_xkb), Ptr{xcb_xkb_sym_interpret_t}, (Ptr{xcb_xkb_set_compat_map_request_t},), R)
+end
+
+function xcb_xkb_set_compat_map_si_length(R)
+    ccall((:xcb_xkb_set_compat_map_si_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_compat_map_request_t},), R)
+end
+
+function xcb_xkb_set_compat_map_si_iterator(R)
+    ccall((:xcb_xkb_set_compat_map_si_iterator, libxcb_xkb), xcb_xkb_sym_interpret_iterator_t, (Ptr{xcb_xkb_set_compat_map_request_t},), R)
+end
+
+function xcb_xkb_set_compat_map_group_maps(R)
+    ccall((:xcb_xkb_set_compat_map_group_maps, libxcb_xkb), Ptr{xcb_xkb_mod_def_t}, (Ptr{xcb_xkb_set_compat_map_request_t},), R)
+end
+
+function xcb_xkb_set_compat_map_group_maps_length(R)
+    ccall((:xcb_xkb_set_compat_map_group_maps_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_compat_map_request_t},), R)
+end
+
+function xcb_xkb_set_compat_map_group_maps_iterator(R)
+    ccall((:xcb_xkb_set_compat_map_group_maps_iterator, libxcb_xkb), xcb_xkb_mod_def_iterator_t, (Ptr{xcb_xkb_set_compat_map_request_t},), R)
+end
+
+function xcb_xkb_get_indicator_state(c, deviceSpec)
+    ccall((:xcb_xkb_get_indicator_state, libxcb_xkb), xcb_xkb_get_indicator_state_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t), c, deviceSpec)
+end
+
+function xcb_xkb_get_indicator_state_unchecked(c, deviceSpec)
+    ccall((:xcb_xkb_get_indicator_state_unchecked, libxcb_xkb), xcb_xkb_get_indicator_state_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t), c, deviceSpec)
+end
+
+function xcb_xkb_get_indicator_state_reply(c, cookie, e)
+    ccall((:xcb_xkb_get_indicator_state_reply, libxcb_xkb), Ptr{xcb_xkb_get_indicator_state_reply_t}, (Ptr{xcb_connection_t}, xcb_xkb_get_indicator_state_cookie_t, Ptr{Ptr{xcb_generic_error_t}}), c, cookie, e)
+end
+
+function xcb_xkb_get_indicator_map_sizeof(_buffer)
+    ccall((:xcb_xkb_get_indicator_map_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_get_indicator_map(c, deviceSpec, which)
+    ccall((:xcb_xkb_get_indicator_map, libxcb_xkb), xcb_xkb_get_indicator_map_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt32), c, deviceSpec, which)
+end
+
+function xcb_xkb_get_indicator_map_unchecked(c, deviceSpec, which)
+    ccall((:xcb_xkb_get_indicator_map_unchecked, libxcb_xkb), xcb_xkb_get_indicator_map_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt32), c, deviceSpec, which)
+end
+
+function xcb_xkb_get_indicator_map_maps(R)
+    ccall((:xcb_xkb_get_indicator_map_maps, libxcb_xkb), Ptr{xcb_xkb_indicator_map_t}, (Ptr{xcb_xkb_get_indicator_map_reply_t},), R)
+end
+
+function xcb_xkb_get_indicator_map_maps_length(R)
+    ccall((:xcb_xkb_get_indicator_map_maps_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_indicator_map_reply_t},), R)
+end
+
+function xcb_xkb_get_indicator_map_maps_iterator(R)
+    ccall((:xcb_xkb_get_indicator_map_maps_iterator, libxcb_xkb), xcb_xkb_indicator_map_iterator_t, (Ptr{xcb_xkb_get_indicator_map_reply_t},), R)
+end
+
+function xcb_xkb_get_indicator_map_reply(c, cookie, e)
+    ccall((:xcb_xkb_get_indicator_map_reply, libxcb_xkb), Ptr{xcb_xkb_get_indicator_map_reply_t}, (Ptr{xcb_connection_t}, xcb_xkb_get_indicator_map_cookie_t, Ptr{Ptr{xcb_generic_error_t}}), c, cookie, e)
+end
+
+function xcb_xkb_set_indicator_map_sizeof(_buffer)
+    ccall((:xcb_xkb_set_indicator_map_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_set_indicator_map_checked(c, deviceSpec, which, maps)
+    ccall((:xcb_xkb_set_indicator_map_checked, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt32, Ptr{xcb_xkb_indicator_map_t}), c, deviceSpec, which, maps)
+end
+
+function xcb_xkb_set_indicator_map(c, deviceSpec, which, maps)
+    ccall((:xcb_xkb_set_indicator_map, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt32, Ptr{xcb_xkb_indicator_map_t}), c, deviceSpec, which, maps)
+end
+
+function xcb_xkb_set_indicator_map_maps(R)
+    ccall((:xcb_xkb_set_indicator_map_maps, libxcb_xkb), Ptr{xcb_xkb_indicator_map_t}, (Ptr{xcb_xkb_set_indicator_map_request_t},), R)
+end
+
+function xcb_xkb_set_indicator_map_maps_length(R)
+    ccall((:xcb_xkb_set_indicator_map_maps_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_indicator_map_request_t},), R)
+end
+
+function xcb_xkb_set_indicator_map_maps_iterator(R)
+    ccall((:xcb_xkb_set_indicator_map_maps_iterator, libxcb_xkb), xcb_xkb_indicator_map_iterator_t, (Ptr{xcb_xkb_set_indicator_map_request_t},), R)
+end
+
+function xcb_xkb_get_named_indicator(c, deviceSpec, ledClass, ledID, indicator)
+    ccall((:xcb_xkb_get_named_indicator, libxcb_xkb), xcb_xkb_get_named_indicator_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, xcb_xkb_led_class_spec_t, xcb_xkb_id_spec_t, xcb_atom_t), c, deviceSpec, ledClass, ledID, indicator)
+end
+
+function xcb_xkb_get_named_indicator_unchecked(c, deviceSpec, ledClass, ledID, indicator)
+    ccall((:xcb_xkb_get_named_indicator_unchecked, libxcb_xkb), xcb_xkb_get_named_indicator_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, xcb_xkb_led_class_spec_t, xcb_xkb_id_spec_t, xcb_atom_t), c, deviceSpec, ledClass, ledID, indicator)
+end
+
+function xcb_xkb_get_named_indicator_reply(c, cookie, e)
+    ccall((:xcb_xkb_get_named_indicator_reply, libxcb_xkb), Ptr{xcb_xkb_get_named_indicator_reply_t}, (Ptr{xcb_connection_t}, xcb_xkb_get_named_indicator_cookie_t, Ptr{Ptr{xcb_generic_error_t}}), c, cookie, e)
+end
+
+function xcb_xkb_set_named_indicator_checked(c, deviceSpec, ledClass, ledID, indicator, setState, on, setMap, createMap, map_flags, map_whichGroups, map_groups, map_whichMods, map_realMods, map_vmods, map_ctrls)
+    ccall((:xcb_xkb_set_named_indicator_checked, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, xcb_xkb_led_class_spec_t, xcb_xkb_id_spec_t, xcb_atom_t, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt16, UInt32), c, deviceSpec, ledClass, ledID, indicator, setState, on, setMap, createMap, map_flags, map_whichGroups, map_groups, map_whichMods, map_realMods, map_vmods, map_ctrls)
+end
+
+function xcb_xkb_set_named_indicator(c, deviceSpec, ledClass, ledID, indicator, setState, on, setMap, createMap, map_flags, map_whichGroups, map_groups, map_whichMods, map_realMods, map_vmods, map_ctrls)
+    ccall((:xcb_xkb_set_named_indicator, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, xcb_xkb_led_class_spec_t, xcb_xkb_id_spec_t, xcb_atom_t, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt16, UInt32), c, deviceSpec, ledClass, ledID, indicator, setState, on, setMap, createMap, map_flags, map_whichGroups, map_groups, map_whichMods, map_realMods, map_vmods, map_ctrls)
+end
+
+function xcb_xkb_get_names_value_list_type_names(S)
+    ccall((:xcb_xkb_get_names_value_list_type_names, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_get_names_value_list_t},), S)
+end
+
+function xcb_xkb_get_names_value_list_type_names_length(R, S)
+    ccall((:xcb_xkb_get_names_value_list_type_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_type_names_end(R, S)
+    ccall((:xcb_xkb_get_names_value_list_type_names_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_n_levels_per_type(S)
+    ccall((:xcb_xkb_get_names_value_list_n_levels_per_type, libxcb_xkb), Ptr{UInt8}, (Ptr{xcb_xkb_get_names_value_list_t},), S)
+end
+
+function xcb_xkb_get_names_value_list_n_levels_per_type_length(R, S)
+    ccall((:xcb_xkb_get_names_value_list_n_levels_per_type_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_n_levels_per_type_end(R, S)
+    ccall((:xcb_xkb_get_names_value_list_n_levels_per_type_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_kt_level_names(S)
+    ccall((:xcb_xkb_get_names_value_list_kt_level_names, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_get_names_value_list_t},), S)
+end
+
+function xcb_xkb_get_names_value_list_kt_level_names_length(R, S)
+    ccall((:xcb_xkb_get_names_value_list_kt_level_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_kt_level_names_end(R, S)
+    ccall((:xcb_xkb_get_names_value_list_kt_level_names_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_indicator_names(S)
+    ccall((:xcb_xkb_get_names_value_list_indicator_names, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_get_names_value_list_t},), S)
+end
+
+function xcb_xkb_get_names_value_list_indicator_names_length(R, S)
+    ccall((:xcb_xkb_get_names_value_list_indicator_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_indicator_names_end(R, S)
+    ccall((:xcb_xkb_get_names_value_list_indicator_names_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_virtual_mod_names(S)
+    ccall((:xcb_xkb_get_names_value_list_virtual_mod_names, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_get_names_value_list_t},), S)
+end
+
+function xcb_xkb_get_names_value_list_virtual_mod_names_length(R, S)
+    ccall((:xcb_xkb_get_names_value_list_virtual_mod_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_virtual_mod_names_end(R, S)
+    ccall((:xcb_xkb_get_names_value_list_virtual_mod_names_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_groups(S)
+    ccall((:xcb_xkb_get_names_value_list_groups, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_get_names_value_list_t},), S)
+end
+
+function xcb_xkb_get_names_value_list_groups_length(R, S)
+    ccall((:xcb_xkb_get_names_value_list_groups_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_groups_end(R, S)
+    ccall((:xcb_xkb_get_names_value_list_groups_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_key_names(S)
+    ccall((:xcb_xkb_get_names_value_list_key_names, libxcb_xkb), Ptr{xcb_xkb_key_name_t}, (Ptr{xcb_xkb_get_names_value_list_t},), S)
+end
+
+function xcb_xkb_get_names_value_list_key_names_length(R, S)
+    ccall((:xcb_xkb_get_names_value_list_key_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_key_names_iterator(R, S)
+    ccall((:xcb_xkb_get_names_value_list_key_names_iterator, libxcb_xkb), xcb_xkb_key_name_iterator_t, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_key_aliases(S)
+    ccall((:xcb_xkb_get_names_value_list_key_aliases, libxcb_xkb), Ptr{xcb_xkb_key_alias_t}, (Ptr{xcb_xkb_get_names_value_list_t},), S)
+end
+
+function xcb_xkb_get_names_value_list_key_aliases_length(R, S)
+    ccall((:xcb_xkb_get_names_value_list_key_aliases_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_key_aliases_iterator(R, S)
+    ccall((:xcb_xkb_get_names_value_list_key_aliases_iterator, libxcb_xkb), xcb_xkb_key_alias_iterator_t, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_radio_group_names(S)
+    ccall((:xcb_xkb_get_names_value_list_radio_group_names, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_get_names_value_list_t},), S)
+end
+
+function xcb_xkb_get_names_value_list_radio_group_names_length(R, S)
+    ccall((:xcb_xkb_get_names_value_list_radio_group_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_radio_group_names_end(R, S)
+    ccall((:xcb_xkb_get_names_value_list_radio_group_names_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_names_reply_t}, Ptr{xcb_xkb_get_names_value_list_t}), R, S)
+end
+
+function xcb_xkb_get_names_value_list_serialize(_buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which, _aux)
+    ccall((:xcb_xkb_get_names_value_list_serialize, libxcb_xkb), Cint, (Ptr{Ptr{Cvoid}}, UInt8, UInt32, UInt16, UInt8, UInt8, UInt8, UInt8, UInt32, Ptr{xcb_xkb_get_names_value_list_t}), _buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which, _aux)
+end
+
+function xcb_xkb_get_names_value_list_unpack(_buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which, _aux)
+    ccall((:xcb_xkb_get_names_value_list_unpack, libxcb_xkb), Cint, (Ptr{Cvoid}, UInt8, UInt32, UInt16, UInt8, UInt8, UInt8, UInt8, UInt32, Ptr{xcb_xkb_get_names_value_list_t}), _buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which, _aux)
+end
+
+function xcb_xkb_get_names_value_list_sizeof(_buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which)
+    ccall((:xcb_xkb_get_names_value_list_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid}, UInt8, UInt32, UInt16, UInt8, UInt8, UInt8, UInt8, UInt32), _buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which)
+end
+
+function xcb_xkb_get_names_sizeof(_buffer)
+    ccall((:xcb_xkb_get_names_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_get_names(c, deviceSpec, which)
+    ccall((:xcb_xkb_get_names, libxcb_xkb), xcb_xkb_get_names_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt32), c, deviceSpec, which)
+end
+
+function xcb_xkb_get_names_unchecked(c, deviceSpec, which)
+    ccall((:xcb_xkb_get_names_unchecked, libxcb_xkb), xcb_xkb_get_names_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt32), c, deviceSpec, which)
+end
+
+function xcb_xkb_get_names_value_list(R)
+    ccall((:xcb_xkb_get_names_value_list, libxcb_xkb), Ptr{Cvoid}, (Ptr{xcb_xkb_get_names_reply_t},), R)
+end
+
+function xcb_xkb_get_names_reply(c, cookie, e)
+    ccall((:xcb_xkb_get_names_reply, libxcb_xkb), Ptr{xcb_xkb_get_names_reply_t}, (Ptr{xcb_connection_t}, xcb_xkb_get_names_cookie_t, Ptr{Ptr{xcb_generic_error_t}}), c, cookie, e)
+end
+
+function xcb_xkb_set_names_values_type_names(S)
+    ccall((:xcb_xkb_set_names_values_type_names, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_set_names_values_t},), S)
+end
+
+function xcb_xkb_set_names_values_type_names_length(R, S)
+    ccall((:xcb_xkb_set_names_values_type_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_type_names_end(R, S)
+    ccall((:xcb_xkb_set_names_values_type_names_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_n_levels_per_type(S)
+    ccall((:xcb_xkb_set_names_values_n_levels_per_type, libxcb_xkb), Ptr{UInt8}, (Ptr{xcb_xkb_set_names_values_t},), S)
+end
+
+function xcb_xkb_set_names_values_n_levels_per_type_length(R, S)
+    ccall((:xcb_xkb_set_names_values_n_levels_per_type_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_n_levels_per_type_end(R, S)
+    ccall((:xcb_xkb_set_names_values_n_levels_per_type_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_kt_level_names(S)
+    ccall((:xcb_xkb_set_names_values_kt_level_names, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_set_names_values_t},), S)
+end
+
+function xcb_xkb_set_names_values_kt_level_names_length(R, S)
+    ccall((:xcb_xkb_set_names_values_kt_level_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_kt_level_names_end(R, S)
+    ccall((:xcb_xkb_set_names_values_kt_level_names_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_indicator_names(S)
+    ccall((:xcb_xkb_set_names_values_indicator_names, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_set_names_values_t},), S)
+end
+
+function xcb_xkb_set_names_values_indicator_names_length(R, S)
+    ccall((:xcb_xkb_set_names_values_indicator_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_indicator_names_end(R, S)
+    ccall((:xcb_xkb_set_names_values_indicator_names_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_virtual_mod_names(S)
+    ccall((:xcb_xkb_set_names_values_virtual_mod_names, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_set_names_values_t},), S)
+end
+
+function xcb_xkb_set_names_values_virtual_mod_names_length(R, S)
+    ccall((:xcb_xkb_set_names_values_virtual_mod_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_virtual_mod_names_end(R, S)
+    ccall((:xcb_xkb_set_names_values_virtual_mod_names_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_groups(S)
+    ccall((:xcb_xkb_set_names_values_groups, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_set_names_values_t},), S)
+end
+
+function xcb_xkb_set_names_values_groups_length(R, S)
+    ccall((:xcb_xkb_set_names_values_groups_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_groups_end(R, S)
+    ccall((:xcb_xkb_set_names_values_groups_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_key_names(S)
+    ccall((:xcb_xkb_set_names_values_key_names, libxcb_xkb), Ptr{xcb_xkb_key_name_t}, (Ptr{xcb_xkb_set_names_values_t},), S)
+end
+
+function xcb_xkb_set_names_values_key_names_length(R, S)
+    ccall((:xcb_xkb_set_names_values_key_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_key_names_iterator(R, S)
+    ccall((:xcb_xkb_set_names_values_key_names_iterator, libxcb_xkb), xcb_xkb_key_name_iterator_t, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_key_aliases(S)
+    ccall((:xcb_xkb_set_names_values_key_aliases, libxcb_xkb), Ptr{xcb_xkb_key_alias_t}, (Ptr{xcb_xkb_set_names_values_t},), S)
+end
+
+function xcb_xkb_set_names_values_key_aliases_length(R, S)
+    ccall((:xcb_xkb_set_names_values_key_aliases_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_key_aliases_iterator(R, S)
+    ccall((:xcb_xkb_set_names_values_key_aliases_iterator, libxcb_xkb), xcb_xkb_key_alias_iterator_t, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_radio_group_names(S)
+    ccall((:xcb_xkb_set_names_values_radio_group_names, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_set_names_values_t},), S)
+end
+
+function xcb_xkb_set_names_values_radio_group_names_length(R, S)
+    ccall((:xcb_xkb_set_names_values_radio_group_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_radio_group_names_end(R, S)
+    ccall((:xcb_xkb_set_names_values_radio_group_names_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_set_names_request_t}, Ptr{xcb_xkb_set_names_values_t}), R, S)
+end
+
+function xcb_xkb_set_names_values_serialize(_buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which, _aux)
+    ccall((:xcb_xkb_set_names_values_serialize, libxcb_xkb), Cint, (Ptr{Ptr{Cvoid}}, UInt8, UInt32, UInt16, UInt8, UInt8, UInt8, UInt8, UInt32, Ptr{xcb_xkb_set_names_values_t}), _buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which, _aux)
+end
+
+function xcb_xkb_set_names_values_unpack(_buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which, _aux)
+    ccall((:xcb_xkb_set_names_values_unpack, libxcb_xkb), Cint, (Ptr{Cvoid}, UInt8, UInt32, UInt16, UInt8, UInt8, UInt8, UInt8, UInt32, Ptr{xcb_xkb_set_names_values_t}), _buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which, _aux)
+end
+
+function xcb_xkb_set_names_values_sizeof(_buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which)
+    ccall((:xcb_xkb_set_names_values_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid}, UInt8, UInt32, UInt16, UInt8, UInt8, UInt8, UInt8, UInt32), _buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which)
+end
+
+function xcb_xkb_set_names_sizeof(_buffer)
+    ccall((:xcb_xkb_set_names_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_set_names_checked(c, deviceSpec, virtualMods, which, firstType, nTypes, firstKTLevelt, nKTLevels, indicators, groupNames, nRadioGroups, firstKey, nKeys, nKeyAliases, totalKTLevelNames, values)
+    ccall((:xcb_xkb_set_names_checked, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt32, UInt8, UInt8, UInt8, UInt8, UInt32, UInt8, UInt8, xcb_keycode_t, UInt8, UInt8, UInt16, Ptr{Cvoid}), c, deviceSpec, virtualMods, which, firstType, nTypes, firstKTLevelt, nKTLevels, indicators, groupNames, nRadioGroups, firstKey, nKeys, nKeyAliases, totalKTLevelNames, values)
+end
+
+function xcb_xkb_set_names(c, deviceSpec, virtualMods, which, firstType, nTypes, firstKTLevelt, nKTLevels, indicators, groupNames, nRadioGroups, firstKey, nKeys, nKeyAliases, totalKTLevelNames, values)
+    ccall((:xcb_xkb_set_names, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt32, UInt8, UInt8, UInt8, UInt8, UInt32, UInt8, UInt8, xcb_keycode_t, UInt8, UInt8, UInt16, Ptr{Cvoid}), c, deviceSpec, virtualMods, which, firstType, nTypes, firstKTLevelt, nKTLevels, indicators, groupNames, nRadioGroups, firstKey, nKeys, nKeyAliases, totalKTLevelNames, values)
+end
+
+function xcb_xkb_set_names_aux_checked(c, deviceSpec, virtualMods, which, firstType, nTypes, firstKTLevelt, nKTLevels, indicators, groupNames, nRadioGroups, firstKey, nKeys, nKeyAliases, totalKTLevelNames, values)
+    ccall((:xcb_xkb_set_names_aux_checked, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt32, UInt8, UInt8, UInt8, UInt8, UInt32, UInt8, UInt8, xcb_keycode_t, UInt8, UInt8, UInt16, Ptr{xcb_xkb_set_names_values_t}), c, deviceSpec, virtualMods, which, firstType, nTypes, firstKTLevelt, nKTLevels, indicators, groupNames, nRadioGroups, firstKey, nKeys, nKeyAliases, totalKTLevelNames, values)
+end
+
+function xcb_xkb_set_names_aux(c, deviceSpec, virtualMods, which, firstType, nTypes, firstKTLevelt, nKTLevels, indicators, groupNames, nRadioGroups, firstKey, nKeys, nKeyAliases, totalKTLevelNames, values)
+    ccall((:xcb_xkb_set_names_aux, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt32, UInt8, UInt8, UInt8, UInt8, UInt32, UInt8, UInt8, xcb_keycode_t, UInt8, UInt8, UInt16, Ptr{xcb_xkb_set_names_values_t}), c, deviceSpec, virtualMods, which, firstType, nTypes, firstKTLevelt, nKTLevels, indicators, groupNames, nRadioGroups, firstKey, nKeys, nKeyAliases, totalKTLevelNames, values)
+end
+
+function xcb_xkb_set_names_values(R)
+    ccall((:xcb_xkb_set_names_values, libxcb_xkb), Ptr{Cvoid}, (Ptr{xcb_xkb_set_names_request_t},), R)
+end
+
+function xcb_xkb_per_client_flags(c, deviceSpec, change, value, ctrlsToChange, autoCtrls, autoCtrlsValues)
+    ccall((:xcb_xkb_per_client_flags, libxcb_xkb), xcb_xkb_per_client_flags_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt32, UInt32, UInt32, UInt32, UInt32), c, deviceSpec, change, value, ctrlsToChange, autoCtrls, autoCtrlsValues)
+end
+
+function xcb_xkb_per_client_flags_unchecked(c, deviceSpec, change, value, ctrlsToChange, autoCtrls, autoCtrlsValues)
+    ccall((:xcb_xkb_per_client_flags_unchecked, libxcb_xkb), xcb_xkb_per_client_flags_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt32, UInt32, UInt32, UInt32, UInt32), c, deviceSpec, change, value, ctrlsToChange, autoCtrls, autoCtrlsValues)
+end
+
+function xcb_xkb_per_client_flags_reply(c, cookie, e)
+    ccall((:xcb_xkb_per_client_flags_reply, libxcb_xkb), Ptr{xcb_xkb_per_client_flags_reply_t}, (Ptr{xcb_connection_t}, xcb_xkb_per_client_flags_cookie_t, Ptr{Ptr{xcb_generic_error_t}}), c, cookie, e)
+end
+
+function xcb_xkb_list_components_sizeof(_buffer)
+    ccall((:xcb_xkb_list_components_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_list_components(c, deviceSpec, maxNames)
+    ccall((:xcb_xkb_list_components, libxcb_xkb), xcb_xkb_list_components_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16), c, deviceSpec, maxNames)
+end
+
+function xcb_xkb_list_components_unchecked(c, deviceSpec, maxNames)
+    ccall((:xcb_xkb_list_components_unchecked, libxcb_xkb), xcb_xkb_list_components_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16), c, deviceSpec, maxNames)
+end
+
+function xcb_xkb_list_components_keymaps_length(R)
+    ccall((:xcb_xkb_list_components_keymaps_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_list_components_reply_t},), R)
+end
+
+function xcb_xkb_list_components_keymaps_iterator(R)
+    ccall((:xcb_xkb_list_components_keymaps_iterator, libxcb_xkb), xcb_xkb_listing_iterator_t, (Ptr{xcb_xkb_list_components_reply_t},), R)
+end
+
+function xcb_xkb_list_components_keycodes_length(R)
+    ccall((:xcb_xkb_list_components_keycodes_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_list_components_reply_t},), R)
+end
+
+function xcb_xkb_list_components_keycodes_iterator(R)
+    ccall((:xcb_xkb_list_components_keycodes_iterator, libxcb_xkb), xcb_xkb_listing_iterator_t, (Ptr{xcb_xkb_list_components_reply_t},), R)
+end
+
+function xcb_xkb_list_components_types_length(R)
+    ccall((:xcb_xkb_list_components_types_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_list_components_reply_t},), R)
+end
+
+function xcb_xkb_list_components_types_iterator(R)
+    ccall((:xcb_xkb_list_components_types_iterator, libxcb_xkb), xcb_xkb_listing_iterator_t, (Ptr{xcb_xkb_list_components_reply_t},), R)
+end
+
+function xcb_xkb_list_components_compat_maps_length(R)
+    ccall((:xcb_xkb_list_components_compat_maps_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_list_components_reply_t},), R)
+end
+
+function xcb_xkb_list_components_compat_maps_iterator(R)
+    ccall((:xcb_xkb_list_components_compat_maps_iterator, libxcb_xkb), xcb_xkb_listing_iterator_t, (Ptr{xcb_xkb_list_components_reply_t},), R)
+end
+
+function xcb_xkb_list_components_symbols_length(R)
+    ccall((:xcb_xkb_list_components_symbols_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_list_components_reply_t},), R)
+end
+
+function xcb_xkb_list_components_symbols_iterator(R)
+    ccall((:xcb_xkb_list_components_symbols_iterator, libxcb_xkb), xcb_xkb_listing_iterator_t, (Ptr{xcb_xkb_list_components_reply_t},), R)
+end
+
+function xcb_xkb_list_components_geometries_length(R)
+    ccall((:xcb_xkb_list_components_geometries_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_list_components_reply_t},), R)
+end
+
+function xcb_xkb_list_components_geometries_iterator(R)
+    ccall((:xcb_xkb_list_components_geometries_iterator, libxcb_xkb), xcb_xkb_listing_iterator_t, (Ptr{xcb_xkb_list_components_reply_t},), R)
+end
+
+function xcb_xkb_list_components_reply(c, cookie, e)
+    ccall((:xcb_xkb_list_components_reply, libxcb_xkb), Ptr{xcb_xkb_list_components_reply_t}, (Ptr{xcb_connection_t}, xcb_xkb_list_components_cookie_t, Ptr{Ptr{xcb_generic_error_t}}), c, cookie, e)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_types_rtrn_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_types_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_types_rtrn_iterator(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_types_rtrn_iterator, libxcb_xkb), xcb_xkb_key_type_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_syms_rtrn_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_syms_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_syms_rtrn_iterator(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_syms_rtrn_iterator, libxcb_xkb), xcb_xkb_key_sym_map_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_acts_rtrn_count(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_acts_rtrn_count, libxcb_xkb), Ptr{UInt8}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_acts_rtrn_count_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_acts_rtrn_count_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_acts_rtrn_count_end(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_acts_rtrn_count_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_acts_rtrn_acts(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_acts_rtrn_acts, libxcb_xkb), Ptr{xcb_xkb_action_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_acts_rtrn_acts_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_acts_rtrn_acts_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_acts_rtrn_acts_iterator(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_acts_rtrn_acts_iterator, libxcb_xkb), xcb_xkb_action_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_behaviors_rtrn(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_behaviors_rtrn, libxcb_xkb), Ptr{xcb_xkb_set_behavior_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_behaviors_rtrn_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_behaviors_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_behaviors_rtrn_iterator(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_behaviors_rtrn_iterator, libxcb_xkb), xcb_xkb_set_behavior_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_vmods_rtrn(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_vmods_rtrn, libxcb_xkb), Ptr{UInt8}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_vmods_rtrn_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_vmods_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_vmods_rtrn_end(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_vmods_rtrn_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_explicit_rtrn(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_explicit_rtrn, libxcb_xkb), Ptr{xcb_xkb_set_explicit_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_explicit_rtrn_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_explicit_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_explicit_rtrn_iterator(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_explicit_rtrn_iterator, libxcb_xkb), xcb_xkb_set_explicit_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_modmap_rtrn(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_modmap_rtrn, libxcb_xkb), Ptr{xcb_xkb_key_mod_map_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_modmap_rtrn_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_modmap_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_modmap_rtrn_iterator(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_modmap_rtrn_iterator, libxcb_xkb), xcb_xkb_key_mod_map_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_vmodmap_rtrn(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_vmodmap_rtrn, libxcb_xkb), Ptr{xcb_xkb_key_v_mod_map_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_vmodmap_rtrn_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_vmodmap_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_vmodmap_rtrn_iterator(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_vmodmap_rtrn_iterator, libxcb_xkb), xcb_xkb_key_v_mod_map_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_serialize(_buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present, _aux)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_serialize, libxcb_xkb), Cint, (Ptr{Ptr{Cvoid}}, UInt8, UInt8, UInt8, UInt16, UInt8, UInt16, UInt8, UInt8, UInt8, UInt16, Ptr{xcb_xkb_get_kbd_by_name_replies_types_map_t}), _buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present, _aux)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_unpack(_buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present, _aux)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_unpack, libxcb_xkb), Cint, (Ptr{Cvoid}, UInt8, UInt8, UInt8, UInt16, UInt8, UInt16, UInt8, UInt8, UInt8, UInt16, Ptr{xcb_xkb_get_kbd_by_name_replies_types_map_t}), _buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present, _aux)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_types_map_sizeof(_buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_types_map_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid}, UInt8, UInt8, UInt8, UInt16, UInt8, UInt16, UInt8, UInt8, UInt8, UInt16), _buffer, nTypes, nKeySyms, nKeyActions, totalActions, totalKeyBehaviors, virtualMods, totalKeyExplicit, totalModMapKeys, totalVModMapKeys, present)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_type_names(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_type_names, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_type_names_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_type_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_type_names_end(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_type_names_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_n_levels_per_type(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_n_levels_per_type, libxcb_xkb), Ptr{UInt8}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_n_levels_per_type_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_n_levels_per_type_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_n_levels_per_type_end(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_n_levels_per_type_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_kt_level_names(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_kt_level_names, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_kt_level_names_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_kt_level_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_kt_level_names_end(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_kt_level_names_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_indicator_names(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_indicator_names, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_indicator_names_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_indicator_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_indicator_names_end(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_indicator_names_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_virtual_mod_names(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_virtual_mod_names, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_virtual_mod_names_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_virtual_mod_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_virtual_mod_names_end(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_virtual_mod_names_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_groups(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_groups, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_groups_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_groups_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_groups_end(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_groups_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_key_names(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_key_names, libxcb_xkb), Ptr{xcb_xkb_key_name_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_key_names_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_key_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_key_names_iterator(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_key_names_iterator, libxcb_xkb), xcb_xkb_key_name_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_key_aliases(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_key_aliases, libxcb_xkb), Ptr{xcb_xkb_key_alias_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_key_aliases_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_key_aliases_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_key_aliases_iterator(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_key_aliases_iterator, libxcb_xkb), xcb_xkb_key_alias_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_radio_group_names(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_radio_group_names, libxcb_xkb), Ptr{xcb_atom_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_radio_group_names_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_radio_group_names_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_radio_group_names_end(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_radio_group_names_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_serialize(_buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which, _aux)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_serialize, libxcb_xkb), Cint, (Ptr{Ptr{Cvoid}}, UInt8, UInt32, UInt16, UInt8, UInt8, UInt8, UInt8, UInt32, Ptr{xcb_xkb_get_kbd_by_name_replies_key_names_value_list_t}), _buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which, _aux)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_unpack(_buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which, _aux)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_unpack, libxcb_xkb), Cint, (Ptr{Cvoid}, UInt8, UInt32, UInt16, UInt8, UInt8, UInt8, UInt8, UInt32, Ptr{xcb_xkb_get_kbd_by_name_replies_key_names_value_list_t}), _buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which, _aux)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list_sizeof(_buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid}, UInt8, UInt32, UInt16, UInt8, UInt8, UInt8, UInt8, UInt32), _buffer, nTypes, indicators, virtualMods, groupNames, nKeys, nKeyAliases, nRadioGroups, which)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_compat_map_si_rtrn(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_compat_map_si_rtrn, libxcb_xkb), Ptr{xcb_xkb_sym_interpret_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_compat_map_si_rtrn_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_compat_map_si_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_compat_map_si_rtrn_iterator(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_compat_map_si_rtrn_iterator, libxcb_xkb), xcb_xkb_sym_interpret_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_compat_map_group_rtrn(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_compat_map_group_rtrn, libxcb_xkb), Ptr{xcb_xkb_mod_def_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_compat_map_group_rtrn_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_compat_map_group_rtrn_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_compat_map_group_rtrn_iterator(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_compat_map_group_rtrn_iterator, libxcb_xkb), xcb_xkb_mod_def_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_indicator_maps_maps(S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_indicator_maps_maps, libxcb_xkb), Ptr{xcb_xkb_indicator_map_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_indicator_maps_maps_length(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_indicator_maps_maps_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_indicator_maps_maps_iterator(R, S)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_indicator_maps_maps_iterator, libxcb_xkb), xcb_xkb_indicator_map_iterator_t, (Ptr{xcb_xkb_get_kbd_by_name_reply_t}, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), R, S)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_key_names_value_list(R)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_key_names_value_list, libxcb_xkb), Ptr{xcb_xkb_get_kbd_by_name_replies_key_names_value_list_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), R)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_geometry_label_font(R)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_geometry_label_font, libxcb_xkb), Ptr{xcb_xkb_counted_string_16_t}, (Ptr{xcb_xkb_get_kbd_by_name_replies_t},), R)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_serialize(_buffer, reported, _aux)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_serialize, libxcb_xkb), Cint, (Ptr{Ptr{Cvoid}}, UInt16, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), _buffer, reported, _aux)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_unpack(_buffer, reported, _aux)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_unpack, libxcb_xkb), Cint, (Ptr{Cvoid}, UInt16, Ptr{xcb_xkb_get_kbd_by_name_replies_t}), _buffer, reported, _aux)
+end
+
+function xcb_xkb_get_kbd_by_name_replies_sizeof(_buffer, reported)
+    ccall((:xcb_xkb_get_kbd_by_name_replies_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid}, UInt16), _buffer, reported)
+end
+
+function xcb_xkb_get_kbd_by_name_sizeof(_buffer)
+    ccall((:xcb_xkb_get_kbd_by_name_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_get_kbd_by_name(c, deviceSpec, need, want, load)
+    ccall((:xcb_xkb_get_kbd_by_name, libxcb_xkb), xcb_xkb_get_kbd_by_name_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt16, UInt8), c, deviceSpec, need, want, load)
+end
+
+function xcb_xkb_get_kbd_by_name_unchecked(c, deviceSpec, need, want, load)
+    ccall((:xcb_xkb_get_kbd_by_name_unchecked, libxcb_xkb), xcb_xkb_get_kbd_by_name_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt16, UInt8), c, deviceSpec, need, want, load)
+end
+
+function xcb_xkb_get_kbd_by_name_replies(R)
+    ccall((:xcb_xkb_get_kbd_by_name_replies, libxcb_xkb), Ptr{Cvoid}, (Ptr{xcb_xkb_get_kbd_by_name_reply_t},), R)
+end
+
+function xcb_xkb_get_kbd_by_name_reply(c, cookie, e)
+    ccall((:xcb_xkb_get_kbd_by_name_reply, libxcb_xkb), Ptr{xcb_xkb_get_kbd_by_name_reply_t}, (Ptr{xcb_connection_t}, xcb_xkb_get_kbd_by_name_cookie_t, Ptr{Ptr{xcb_generic_error_t}}), c, cookie, e)
+end
+
+function xcb_xkb_get_device_info_sizeof(_buffer)
+    ccall((:xcb_xkb_get_device_info_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_get_device_info(c, deviceSpec, wanted, allButtons, firstButton, nButtons, ledClass, ledID)
+    ccall((:xcb_xkb_get_device_info, libxcb_xkb), xcb_xkb_get_device_info_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt8, UInt8, UInt8, xcb_xkb_led_class_spec_t, xcb_xkb_id_spec_t), c, deviceSpec, wanted, allButtons, firstButton, nButtons, ledClass, ledID)
+end
+
+function xcb_xkb_get_device_info_unchecked(c, deviceSpec, wanted, allButtons, firstButton, nButtons, ledClass, ledID)
+    ccall((:xcb_xkb_get_device_info_unchecked, libxcb_xkb), xcb_xkb_get_device_info_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt16, UInt8, UInt8, UInt8, xcb_xkb_led_class_spec_t, xcb_xkb_id_spec_t), c, deviceSpec, wanted, allButtons, firstButton, nButtons, ledClass, ledID)
+end
+
+function xcb_xkb_get_device_info_name(R)
+    ccall((:xcb_xkb_get_device_info_name, libxcb_xkb), Ptr{xcb_xkb_string8_t}, (Ptr{xcb_xkb_get_device_info_reply_t},), R)
+end
+
+function xcb_xkb_get_device_info_name_length(R)
+    ccall((:xcb_xkb_get_device_info_name_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_device_info_reply_t},), R)
+end
+
+function xcb_xkb_get_device_info_name_end(R)
+    ccall((:xcb_xkb_get_device_info_name_end, libxcb_xkb), xcb_generic_iterator_t, (Ptr{xcb_xkb_get_device_info_reply_t},), R)
+end
+
+function xcb_xkb_get_device_info_btn_actions(R)
+    ccall((:xcb_xkb_get_device_info_btn_actions, libxcb_xkb), Ptr{xcb_xkb_action_t}, (Ptr{xcb_xkb_get_device_info_reply_t},), R)
+end
+
+function xcb_xkb_get_device_info_btn_actions_length(R)
+    ccall((:xcb_xkb_get_device_info_btn_actions_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_device_info_reply_t},), R)
+end
+
+function xcb_xkb_get_device_info_btn_actions_iterator(R)
+    ccall((:xcb_xkb_get_device_info_btn_actions_iterator, libxcb_xkb), xcb_xkb_action_iterator_t, (Ptr{xcb_xkb_get_device_info_reply_t},), R)
+end
+
+function xcb_xkb_get_device_info_leds_length(R)
+    ccall((:xcb_xkb_get_device_info_leds_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_get_device_info_reply_t},), R)
+end
+
+function xcb_xkb_get_device_info_leds_iterator(R)
+    ccall((:xcb_xkb_get_device_info_leds_iterator, libxcb_xkb), xcb_xkb_device_led_info_iterator_t, (Ptr{xcb_xkb_get_device_info_reply_t},), R)
+end
+
+function xcb_xkb_get_device_info_reply(c, cookie, e)
+    ccall((:xcb_xkb_get_device_info_reply, libxcb_xkb), Ptr{xcb_xkb_get_device_info_reply_t}, (Ptr{xcb_connection_t}, xcb_xkb_get_device_info_cookie_t, Ptr{Ptr{xcb_generic_error_t}}), c, cookie, e)
+end
+
+function xcb_xkb_set_device_info_sizeof(_buffer)
+    ccall((:xcb_xkb_set_device_info_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_set_device_info_checked(c, deviceSpec, firstBtn, nBtns, change, nDeviceLedFBs, btnActions, leds)
+    ccall((:xcb_xkb_set_device_info_checked, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt8, UInt8, UInt16, UInt16, Ptr{xcb_xkb_action_t}, Ptr{xcb_xkb_device_led_info_t}), c, deviceSpec, firstBtn, nBtns, change, nDeviceLedFBs, btnActions, leds)
+end
+
+function xcb_xkb_set_device_info(c, deviceSpec, firstBtn, nBtns, change, nDeviceLedFBs, btnActions, leds)
+    ccall((:xcb_xkb_set_device_info, libxcb_xkb), xcb_void_cookie_t, (Ptr{xcb_connection_t}, xcb_xkb_device_spec_t, UInt8, UInt8, UInt16, UInt16, Ptr{xcb_xkb_action_t}, Ptr{xcb_xkb_device_led_info_t}), c, deviceSpec, firstBtn, nBtns, change, nDeviceLedFBs, btnActions, leds)
+end
+
+function xcb_xkb_set_device_info_btn_actions(R)
+    ccall((:xcb_xkb_set_device_info_btn_actions, libxcb_xkb), Ptr{xcb_xkb_action_t}, (Ptr{xcb_xkb_set_device_info_request_t},), R)
+end
+
+function xcb_xkb_set_device_info_btn_actions_length(R)
+    ccall((:xcb_xkb_set_device_info_btn_actions_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_device_info_request_t},), R)
+end
+
+function xcb_xkb_set_device_info_btn_actions_iterator(R)
+    ccall((:xcb_xkb_set_device_info_btn_actions_iterator, libxcb_xkb), xcb_xkb_action_iterator_t, (Ptr{xcb_xkb_set_device_info_request_t},), R)
+end
+
+function xcb_xkb_set_device_info_leds_length(R)
+    ccall((:xcb_xkb_set_device_info_leds_length, libxcb_xkb), Cint, (Ptr{xcb_xkb_set_device_info_request_t},), R)
+end
+
+function xcb_xkb_set_device_info_leds_iterator(R)
+    ccall((:xcb_xkb_set_device_info_leds_iterator, libxcb_xkb), xcb_xkb_device_led_info_iterator_t, (Ptr{xcb_xkb_set_device_info_request_t},), R)
+end
+
+function xcb_xkb_set_debugging_flags_sizeof(_buffer)
+    ccall((:xcb_xkb_set_debugging_flags_sizeof, libxcb_xkb), Cint, (Ptr{Cvoid},), _buffer)
+end
+
+function xcb_xkb_set_debugging_flags(c, msgLength, affectFlags, flags, affectCtrls, ctrls, message)
+    ccall((:xcb_xkb_set_debugging_flags, libxcb_xkb), xcb_xkb_set_debugging_flags_cookie_t, (Ptr{xcb_connection_t}, UInt16, UInt32, UInt32, UInt32, UInt32, Ptr{xcb_xkb_string8_t}), c, msgLength, affectFlags, flags, affectCtrls, ctrls, message)
+end
+
+function xcb_xkb_set_debugging_flags_unchecked(c, msgLength, affectFlags, flags, affectCtrls, ctrls, message)
+    ccall((:xcb_xkb_set_debugging_flags_unchecked, libxcb_xkb), xcb_xkb_set_debugging_flags_cookie_t, (Ptr{xcb_connection_t}, UInt16, UInt32, UInt32, UInt32, UInt32, Ptr{xcb_xkb_string8_t}), c, msgLength, affectFlags, flags, affectCtrls, ctrls, message)
+end
+
+function xcb_xkb_set_debugging_flags_reply(c, cookie, e)
+    ccall((:xcb_xkb_set_debugging_flags_reply, libxcb_xkb), Ptr{xcb_xkb_set_debugging_flags_reply_t}, (Ptr{xcb_connection_t}, xcb_xkb_set_debugging_flags_cookie_t, Ptr{Ptr{xcb_generic_error_t}}), c, cookie, e)
 end
 # Julia wrapper for header: xcb_keysyms.h
 # Automatically generated using Clang.jl

--- a/gen/xcb_common.jl
+++ b/gen/xcb_common.jl
@@ -191,6 +191,45 @@ const XCB_NONE = Int32(0)
 const XCB_COPY_FROM_PARENT = Int32(0)
 const XCB_CURRENT_TIME = Int32(0)
 const XCB_NO_SYMBOL = Int32(0)
+const XCB_XKB_MAJOR_VERSION = 1
+const XCB_XKB_MINOR_VERSION = 0
+const XCB_XKB_KEYBOARD = 0
+const XCB_XKB_USE_EXTENSION = 0
+const XCB_XKB_SELECT_EVENTS = 1
+const XCB_XKB_BELL = 3
+const XCB_XKB_GET_STATE = 4
+const XCB_XKB_LATCH_LOCK_STATE = 5
+const XCB_XKB_GET_CONTROLS = 6
+const XCB_XKB_SET_CONTROLS = 7
+const XCB_XKB_GET_MAP = 8
+const XCB_XKB_SET_MAP = 9
+const XCB_XKB_GET_COMPAT_MAP = 10
+const XCB_XKB_SET_COMPAT_MAP = 11
+const XCB_XKB_GET_INDICATOR_STATE = 12
+const XCB_XKB_GET_INDICATOR_MAP = 13
+const XCB_XKB_SET_INDICATOR_MAP = 14
+const XCB_XKB_GET_NAMED_INDICATOR = 15
+const XCB_XKB_SET_NAMED_INDICATOR = 16
+const XCB_XKB_GET_NAMES = 17
+const XCB_XKB_SET_NAMES = 18
+const XCB_XKB_PER_CLIENT_FLAGS = 21
+const XCB_XKB_LIST_COMPONENTS = 22
+const XCB_XKB_GET_KBD_BY_NAME = 23
+const XCB_XKB_GET_DEVICE_INFO = 24
+const XCB_XKB_SET_DEVICE_INFO = 25
+const XCB_XKB_SET_DEBUGGING_FLAGS = 101
+const XCB_XKB_NEW_KEYBOARD_NOTIFY = 0
+const XCB_XKB_MAP_NOTIFY = 1
+const XCB_XKB_STATE_NOTIFY = 2
+const XCB_XKB_CONTROLS_NOTIFY = 3
+const XCB_XKB_INDICATOR_STATE_NOTIFY = 4
+const XCB_XKB_INDICATOR_MAP_NOTIFY = 5
+const XCB_XKB_NAMES_NOTIFY = 6
+const XCB_XKB_COMPAT_MAP_NOTIFY = 7
+const XCB_XKB_BELL_NOTIFY = 8
+const XCB_XKB_ACTION_MESSAGE = 9
+const XCB_XKB_ACCESS_X_NOTIFY = 10
+const XCB_XKB_EXTENSION_DEVICE_NOTIFY = 11
 const xcb_connection_t = Cvoid
 
 struct xcb_generic_iterator_t
@@ -3439,5 +3478,2337 @@ end
 const xcb_special_event = Cvoid
 const xcb_special_event_t = xcb_special_event
 const xcb_extension_t = Cvoid
+
+@cenum xcb_xkb_const_t::UInt32 begin
+    XCB_XKB_CONST_MAX_LEGAL_KEY_CODE = 255
+    XCB_XKB_CONST_PER_KEY_BIT_ARRAY_SIZE = 32
+    XCB_XKB_CONST_KEY_NAME_LENGTH = 4
+end
+
+@cenum xcb_xkb_event_type_t::UInt32 begin
+    XCB_XKB_EVENT_TYPE_NEW_KEYBOARD_NOTIFY = 1
+    XCB_XKB_EVENT_TYPE_MAP_NOTIFY = 2
+    XCB_XKB_EVENT_TYPE_STATE_NOTIFY = 4
+    XCB_XKB_EVENT_TYPE_CONTROLS_NOTIFY = 8
+    XCB_XKB_EVENT_TYPE_INDICATOR_STATE_NOTIFY = 16
+    XCB_XKB_EVENT_TYPE_INDICATOR_MAP_NOTIFY = 32
+    XCB_XKB_EVENT_TYPE_NAMES_NOTIFY = 64
+    XCB_XKB_EVENT_TYPE_COMPAT_MAP_NOTIFY = 128
+    XCB_XKB_EVENT_TYPE_BELL_NOTIFY = 256
+    XCB_XKB_EVENT_TYPE_ACTION_MESSAGE = 512
+    XCB_XKB_EVENT_TYPE_ACCESS_X_NOTIFY = 1024
+    XCB_XKB_EVENT_TYPE_EXTENSION_DEVICE_NOTIFY = 2048
+end
+
+@cenum xcb_xkb_nkn_detail_t::UInt32 begin
+    XCB_XKB_NKN_DETAIL_KEYCODES = 1
+    XCB_XKB_NKN_DETAIL_GEOMETRY = 2
+    XCB_XKB_NKN_DETAIL_DEVICE_ID = 4
+end
+
+@cenum xcb_xkb_axn_detail_t::UInt32 begin
+    XCB_XKB_AXN_DETAIL_SK_PRESS = 1
+    XCB_XKB_AXN_DETAIL_SK_ACCEPT = 2
+    XCB_XKB_AXN_DETAIL_SK_REJECT = 4
+    XCB_XKB_AXN_DETAIL_SK_RELEASE = 8
+    XCB_XKB_AXN_DETAIL_BK_ACCEPT = 16
+    XCB_XKB_AXN_DETAIL_BK_REJECT = 32
+    XCB_XKB_AXN_DETAIL_AXK_WARNING = 64
+end
+
+@cenum xcb_xkb_map_part_t::UInt32 begin
+    XCB_XKB_MAP_PART_KEY_TYPES = 1
+    XCB_XKB_MAP_PART_KEY_SYMS = 2
+    XCB_XKB_MAP_PART_MODIFIER_MAP = 4
+    XCB_XKB_MAP_PART_EXPLICIT_COMPONENTS = 8
+    XCB_XKB_MAP_PART_KEY_ACTIONS = 16
+    XCB_XKB_MAP_PART_KEY_BEHAVIORS = 32
+    XCB_XKB_MAP_PART_VIRTUAL_MODS = 64
+    XCB_XKB_MAP_PART_VIRTUAL_MOD_MAP = 128
+end
+
+@cenum xcb_xkb_set_map_flags_t::UInt32 begin
+    XCB_XKB_SET_MAP_FLAGS_RESIZE_TYPES = 1
+    XCB_XKB_SET_MAP_FLAGS_RECOMPUTE_ACTIONS = 2
+end
+
+@cenum xcb_xkb_state_part_t::UInt32 begin
+    XCB_XKB_STATE_PART_MODIFIER_STATE = 1
+    XCB_XKB_STATE_PART_MODIFIER_BASE = 2
+    XCB_XKB_STATE_PART_MODIFIER_LATCH = 4
+    XCB_XKB_STATE_PART_MODIFIER_LOCK = 8
+    XCB_XKB_STATE_PART_GROUP_STATE = 16
+    XCB_XKB_STATE_PART_GROUP_BASE = 32
+    XCB_XKB_STATE_PART_GROUP_LATCH = 64
+    XCB_XKB_STATE_PART_GROUP_LOCK = 128
+    XCB_XKB_STATE_PART_COMPAT_STATE = 256
+    XCB_XKB_STATE_PART_GRAB_MODS = 512
+    XCB_XKB_STATE_PART_COMPAT_GRAB_MODS = 1024
+    XCB_XKB_STATE_PART_LOOKUP_MODS = 2048
+    XCB_XKB_STATE_PART_COMPAT_LOOKUP_MODS = 4096
+    XCB_XKB_STATE_PART_POINTER_BUTTONS = 8192
+end
+
+@cenum xcb_xkb_bool_ctrl_t::UInt32 begin
+    XCB_XKB_BOOL_CTRL_REPEAT_KEYS = 1
+    XCB_XKB_BOOL_CTRL_SLOW_KEYS = 2
+    XCB_XKB_BOOL_CTRL_BOUNCE_KEYS = 4
+    XCB_XKB_BOOL_CTRL_STICKY_KEYS = 8
+    XCB_XKB_BOOL_CTRL_MOUSE_KEYS = 16
+    XCB_XKB_BOOL_CTRL_MOUSE_KEYS_ACCEL = 32
+    XCB_XKB_BOOL_CTRL_ACCESS_X_KEYS = 64
+    XCB_XKB_BOOL_CTRL_ACCESS_X_TIMEOUT_MASK = 128
+    XCB_XKB_BOOL_CTRL_ACCESS_X_FEEDBACK_MASK = 256
+    XCB_XKB_BOOL_CTRL_AUDIBLE_BELL_MASK = 512
+    XCB_XKB_BOOL_CTRL_OVERLAY_1_MASK = 1024
+    XCB_XKB_BOOL_CTRL_OVERLAY_2_MASK = 2048
+    XCB_XKB_BOOL_CTRL_IGNORE_GROUP_LOCK_MASK = 4096
+end
+
+@cenum xcb_xkb_control_t::UInt32 begin
+    XCB_XKB_CONTROL_GROUPS_WRAP = 134217728
+    XCB_XKB_CONTROL_INTERNAL_MODS = 268435456
+    XCB_XKB_CONTROL_IGNORE_LOCK_MODS = 536870912
+    XCB_XKB_CONTROL_PER_KEY_REPEAT = 1073741824
+    XCB_XKB_CONTROL_CONTROLS_ENABLED = 2147483648
+end
+
+@cenum xcb_xkb_ax_option_t::UInt32 begin
+    XCB_XKB_AX_OPTION_SK_PRESS_FB = 1
+    XCB_XKB_AX_OPTION_SK_ACCEPT_FB = 2
+    XCB_XKB_AX_OPTION_FEATURE_FB = 4
+    XCB_XKB_AX_OPTION_SLOW_WARN_FB = 8
+    XCB_XKB_AX_OPTION_INDICATOR_FB = 16
+    XCB_XKB_AX_OPTION_STICKY_KEYS_FB = 32
+    XCB_XKB_AX_OPTION_TWO_KEYS = 64
+    XCB_XKB_AX_OPTION_LATCH_TO_LOCK = 128
+    XCB_XKB_AX_OPTION_SK_RELEASE_FB = 256
+    XCB_XKB_AX_OPTION_SK_REJECT_FB = 512
+    XCB_XKB_AX_OPTION_BK_REJECT_FB = 1024
+    XCB_XKB_AX_OPTION_DUMB_BELL = 2048
+end
+
+
+const xcb_xkb_device_spec_t = UInt16
+
+struct xcb_xkb_device_spec_iterator_t
+    data::Ptr{xcb_xkb_device_spec_t}
+    rem::Cint
+    index::Cint
+end
+
+@cenum xcb_xkb_led_class_result_t::UInt32 begin
+    XCB_XKB_LED_CLASS_RESULT_KBD_FEEDBACK_CLASS = 0
+    XCB_XKB_LED_CLASS_RESULT_LED_FEEDBACK_CLASS = 4
+end
+
+@cenum xcb_xkb_led_class_t::UInt32 begin
+    XCB_XKB_LED_CLASS_KBD_FEEDBACK_CLASS = 0
+    XCB_XKB_LED_CLASS_LED_FEEDBACK_CLASS = 4
+    XCB_XKB_LED_CLASS_DFLT_XI_CLASS = 768
+    XCB_XKB_LED_CLASS_ALL_XI_CLASSES = 1280
+end
+
+
+const xcb_xkb_led_class_spec_t = UInt16
+
+struct xcb_xkb_led_class_spec_iterator_t
+    data::Ptr{xcb_xkb_led_class_spec_t}
+    rem::Cint
+    index::Cint
+end
+
+@cenum xcb_xkb_bell_class_result_t::UInt32 begin
+    XCB_XKB_BELL_CLASS_RESULT_KBD_FEEDBACK_CLASS = 0
+    XCB_XKB_BELL_CLASS_RESULT_BELL_FEEDBACK_CLASS = 5
+end
+
+@cenum xcb_xkb_bell_class_t::UInt32 begin
+    XCB_XKB_BELL_CLASS_KBD_FEEDBACK_CLASS = 0
+    XCB_XKB_BELL_CLASS_BELL_FEEDBACK_CLASS = 5
+    XCB_XKB_BELL_CLASS_DFLT_XI_CLASS = 768
+end
+
+
+const xcb_xkb_bell_class_spec_t = UInt16
+
+struct xcb_xkb_bell_class_spec_iterator_t
+    data::Ptr{xcb_xkb_bell_class_spec_t}
+    rem::Cint
+    index::Cint
+end
+
+@cenum xcb_xkb_id_t::UInt32 begin
+    XCB_XKB_ID_USE_CORE_KBD = 256
+    XCB_XKB_ID_USE_CORE_PTR = 512
+    XCB_XKB_ID_DFLT_XI_CLASS = 768
+    XCB_XKB_ID_DFLT_XI_ID = 1024
+    XCB_XKB_ID_ALL_XI_CLASS = 1280
+    XCB_XKB_ID_ALL_XI_ID = 1536
+    XCB_XKB_ID_XI_NONE = 65280
+end
+
+
+const xcb_xkb_id_spec_t = UInt16
+
+struct xcb_xkb_id_spec_iterator_t
+    data::Ptr{xcb_xkb_id_spec_t}
+    rem::Cint
+    index::Cint
+end
+
+@cenum xcb_xkb_group_t::UInt32 begin
+    XCB_XKB_GROUP_1 = 0
+    XCB_XKB_GROUP_2 = 1
+    XCB_XKB_GROUP_3 = 2
+    XCB_XKB_GROUP_4 = 3
+end
+
+@cenum xcb_xkb_groups_t::UInt32 begin
+    XCB_XKB_GROUPS_ANY = 254
+    XCB_XKB_GROUPS_ALL = 255
+end
+
+@cenum xcb_xkb_set_of_group_t::UInt32 begin
+    XCB_XKB_SET_OF_GROUP_GROUP_1 = 1
+    XCB_XKB_SET_OF_GROUP_GROUP_2 = 2
+    XCB_XKB_SET_OF_GROUP_GROUP_3 = 4
+    XCB_XKB_SET_OF_GROUP_GROUP_4 = 8
+end
+
+@cenum xcb_xkb_set_of_groups_t::UInt32 begin
+    XCB_XKB_SET_OF_GROUPS_ANY = 128
+end
+
+@cenum xcb_xkb_groups_wrap_t::UInt32 begin
+    XCB_XKB_GROUPS_WRAP_WRAP_INTO_RANGE = 0
+    XCB_XKB_GROUPS_WRAP_CLAMP_INTO_RANGE = 64
+    XCB_XKB_GROUPS_WRAP_REDIRECT_INTO_RANGE = 128
+end
+
+@cenum xcb_xkb_v_mods_high_t::UInt32 begin
+    XCB_XKB_V_MODS_HIGH_15 = 128
+    XCB_XKB_V_MODS_HIGH_14 = 64
+    XCB_XKB_V_MODS_HIGH_13 = 32
+    XCB_XKB_V_MODS_HIGH_12 = 16
+    XCB_XKB_V_MODS_HIGH_11 = 8
+    XCB_XKB_V_MODS_HIGH_10 = 4
+    XCB_XKB_V_MODS_HIGH_9 = 2
+    XCB_XKB_V_MODS_HIGH_8 = 1
+end
+
+@cenum xcb_xkb_v_mods_low_t::UInt32 begin
+    XCB_XKB_V_MODS_LOW_7 = 128
+    XCB_XKB_V_MODS_LOW_6 = 64
+    XCB_XKB_V_MODS_LOW_5 = 32
+    XCB_XKB_V_MODS_LOW_4 = 16
+    XCB_XKB_V_MODS_LOW_3 = 8
+    XCB_XKB_V_MODS_LOW_2 = 4
+    XCB_XKB_V_MODS_LOW_1 = 2
+    XCB_XKB_V_MODS_LOW_0 = 1
+end
+
+@cenum xcb_xkb_v_mod_t::UInt32 begin
+    XCB_XKB_V_MOD_15 = 32768
+    XCB_XKB_V_MOD_14 = 16384
+    XCB_XKB_V_MOD_13 = 8192
+    XCB_XKB_V_MOD_12 = 4096
+    XCB_XKB_V_MOD_11 = 2048
+    XCB_XKB_V_MOD_10 = 1024
+    XCB_XKB_V_MOD_9 = 512
+    XCB_XKB_V_MOD_8 = 256
+    XCB_XKB_V_MOD_7 = 128
+    XCB_XKB_V_MOD_6 = 64
+    XCB_XKB_V_MOD_5 = 32
+    XCB_XKB_V_MOD_4 = 16
+    XCB_XKB_V_MOD_3 = 8
+    XCB_XKB_V_MOD_2 = 4
+    XCB_XKB_V_MOD_1 = 2
+    XCB_XKB_V_MOD_0 = 1
+end
+
+@cenum xcb_xkb_explicit_t::UInt32 begin
+    XCB_XKB_EXPLICIT_V_MOD_MAP = 128
+    XCB_XKB_EXPLICIT_BEHAVIOR = 64
+    XCB_XKB_EXPLICIT_AUTO_REPEAT = 32
+    XCB_XKB_EXPLICIT_INTERPRET = 16
+    XCB_XKB_EXPLICIT_KEY_TYPE_4 = 8
+    XCB_XKB_EXPLICIT_KEY_TYPE_3 = 4
+    XCB_XKB_EXPLICIT_KEY_TYPE_2 = 2
+    XCB_XKB_EXPLICIT_KEY_TYPE_1 = 1
+end
+
+@cenum xcb_xkb_sym_interpret_match_t::UInt32 begin
+    XCB_XKB_SYM_INTERPRET_MATCH_NONE_OF = 0
+    XCB_XKB_SYM_INTERPRET_MATCH_ANY_OF_OR_NONE = 1
+    XCB_XKB_SYM_INTERPRET_MATCH_ANY_OF = 2
+    XCB_XKB_SYM_INTERPRET_MATCH_ALL_OF = 3
+    XCB_XKB_SYM_INTERPRET_MATCH_EXACTLY = 4
+end
+
+@cenum xcb_xkb_sym_interp_match_t::UInt32 begin
+    XCB_XKB_SYM_INTERP_MATCH_LEVEL_ONE_ONLY = 128
+    XCB_XKB_SYM_INTERP_MATCH_OP_MASK = 127
+end
+
+@cenum xcb_xkb_im_flag_t::UInt32 begin
+    XCB_XKB_IM_FLAG_NO_EXPLICIT = 128
+    XCB_XKB_IM_FLAG_NO_AUTOMATIC = 64
+    XCB_XKB_IM_FLAG_LED_DRIVES_KB = 32
+end
+
+@cenum xcb_xkb_im_mods_which_t::UInt32 begin
+    XCB_XKB_IM_MODS_WHICH_USE_COMPAT = 16
+    XCB_XKB_IM_MODS_WHICH_USE_EFFECTIVE = 8
+    XCB_XKB_IM_MODS_WHICH_USE_LOCKED = 4
+    XCB_XKB_IM_MODS_WHICH_USE_LATCHED = 2
+    XCB_XKB_IM_MODS_WHICH_USE_BASE = 1
+end
+
+@cenum xcb_xkb_im_groups_which_t::UInt32 begin
+    XCB_XKB_IM_GROUPS_WHICH_USE_COMPAT = 16
+    XCB_XKB_IM_GROUPS_WHICH_USE_EFFECTIVE = 8
+    XCB_XKB_IM_GROUPS_WHICH_USE_LOCKED = 4
+    XCB_XKB_IM_GROUPS_WHICH_USE_LATCHED = 2
+    XCB_XKB_IM_GROUPS_WHICH_USE_BASE = 1
+end
+
+
+struct xcb_xkb_indicator_map_t
+    flags::UInt8
+    whichGroups::UInt8
+    groups::UInt8
+    whichMods::UInt8
+    mods::UInt8
+    realMods::UInt8
+    vmods::UInt16
+    ctrls::UInt32
+end
+
+struct xcb_xkb_indicator_map_iterator_t
+    data::Ptr{xcb_xkb_indicator_map_t}
+    rem::Cint
+    index::Cint
+end
+
+@cenum xcb_xkb_cm_detail_t::UInt32 begin
+    XCB_XKB_CM_DETAIL_SYM_INTERP = 1
+    XCB_XKB_CM_DETAIL_GROUP_COMPAT = 2
+end
+
+@cenum xcb_xkb_name_detail_t::UInt32 begin
+    XCB_XKB_NAME_DETAIL_KEYCODES = 1
+    XCB_XKB_NAME_DETAIL_GEOMETRY = 2
+    XCB_XKB_NAME_DETAIL_SYMBOLS = 4
+    XCB_XKB_NAME_DETAIL_PHYS_SYMBOLS = 8
+    XCB_XKB_NAME_DETAIL_TYPES = 16
+    XCB_XKB_NAME_DETAIL_COMPAT = 32
+    XCB_XKB_NAME_DETAIL_KEY_TYPE_NAMES = 64
+    XCB_XKB_NAME_DETAIL_KT_LEVEL_NAMES = 128
+    XCB_XKB_NAME_DETAIL_INDICATOR_NAMES = 256
+    XCB_XKB_NAME_DETAIL_KEY_NAMES = 512
+    XCB_XKB_NAME_DETAIL_KEY_ALIASES = 1024
+    XCB_XKB_NAME_DETAIL_VIRTUAL_MOD_NAMES = 2048
+    XCB_XKB_NAME_DETAIL_GROUP_NAMES = 4096
+    XCB_XKB_NAME_DETAIL_RG_NAMES = 8192
+end
+
+@cenum xcb_xkb_gbn_detail_t::UInt32 begin
+    XCB_XKB_GBN_DETAIL_TYPES = 1
+    XCB_XKB_GBN_DETAIL_COMPAT_MAP = 2
+    XCB_XKB_GBN_DETAIL_CLIENT_SYMBOLS = 4
+    XCB_XKB_GBN_DETAIL_SERVER_SYMBOLS = 8
+    XCB_XKB_GBN_DETAIL_INDICATOR_MAPS = 16
+    XCB_XKB_GBN_DETAIL_KEY_NAMES = 32
+    XCB_XKB_GBN_DETAIL_GEOMETRY = 64
+    XCB_XKB_GBN_DETAIL_OTHER_NAMES = 128
+end
+
+@cenum xcb_xkb_xi_feature_t::UInt32 begin
+    XCB_XKB_XI_FEATURE_KEYBOARDS = 1
+    XCB_XKB_XI_FEATURE_BUTTON_ACTIONS = 2
+    XCB_XKB_XI_FEATURE_INDICATOR_NAMES = 4
+    XCB_XKB_XI_FEATURE_INDICATOR_MAPS = 8
+    XCB_XKB_XI_FEATURE_INDICATOR_STATE = 16
+end
+
+@cenum xcb_xkb_per_client_flag_t::UInt32 begin
+    XCB_XKB_PER_CLIENT_FLAG_DETECTABLE_AUTO_REPEAT = 1
+    XCB_XKB_PER_CLIENT_FLAG_GRABS_USE_XKB_STATE = 2
+    XCB_XKB_PER_CLIENT_FLAG_AUTO_RESET_CONTROLS = 4
+    XCB_XKB_PER_CLIENT_FLAG_LOOKUP_STATE_WHEN_GRABBED = 8
+    XCB_XKB_PER_CLIENT_FLAG_SEND_EVENT_USES_XKB_STATE = 16
+end
+
+
+struct xcb_xkb_mod_def_t
+    mask::UInt8
+    realMods::UInt8
+    vmods::UInt16
+end
+
+struct xcb_xkb_mod_def_iterator_t
+    data::Ptr{xcb_xkb_mod_def_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_key_name_t
+    name::NTuple{4, UInt8}
+end
+
+struct xcb_xkb_key_name_iterator_t
+    data::Ptr{xcb_xkb_key_name_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_key_alias_t
+    real::NTuple{4, UInt8}
+    alias::NTuple{4, UInt8}
+end
+
+struct xcb_xkb_key_alias_iterator_t
+    data::Ptr{xcb_xkb_key_alias_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_counted_string_16_t
+    length::UInt16
+end
+
+struct xcb_xkb_counted_string_16_iterator_t
+    data::Ptr{xcb_xkb_counted_string_16_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_kt_map_entry_t
+    active::UInt8
+    mods_mask::UInt8
+    level::UInt8
+    mods_mods::UInt8
+    mods_vmods::UInt16
+    pad0::NTuple{2, UInt8}
+end
+
+struct xcb_xkb_kt_map_entry_iterator_t
+    data::Ptr{xcb_xkb_kt_map_entry_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_key_type_t
+    mods_mask::UInt8
+    mods_mods::UInt8
+    mods_vmods::UInt16
+    numLevels::UInt8
+    nMapEntries::UInt8
+    hasPreserve::UInt8
+    pad0::UInt8
+end
+
+struct xcb_xkb_key_type_iterator_t
+    data::Ptr{xcb_xkb_key_type_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_key_sym_map_t
+    kt_index::NTuple{4, UInt8}
+    groupInfo::UInt8
+    width::UInt8
+    nSyms::UInt16
+end
+
+struct xcb_xkb_key_sym_map_iterator_t
+    data::Ptr{xcb_xkb_key_sym_map_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_common_behavior_t
+    type::UInt8
+    data::UInt8
+end
+
+struct xcb_xkb_common_behavior_iterator_t
+    data::Ptr{xcb_xkb_common_behavior_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_default_behavior_t
+    type::UInt8
+    pad0::UInt8
+end
+
+struct xcb_xkb_default_behavior_iterator_t
+    data::Ptr{xcb_xkb_default_behavior_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_lock_behavior_t
+    type::UInt8
+    pad0::UInt8
+end
+
+struct xcb_xkb_lock_behavior_iterator_t
+    data::Ptr{xcb_xkb_lock_behavior_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_radio_group_behavior_t
+    type::UInt8
+    group::UInt8
+end
+
+struct xcb_xkb_radio_group_behavior_iterator_t
+    data::Ptr{xcb_xkb_radio_group_behavior_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_overlay_behavior_t
+    type::UInt8
+    key::xcb_keycode_t
+end
+
+struct xcb_xkb_overlay_behavior_iterator_t
+    data::Ptr{xcb_xkb_overlay_behavior_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_permament_lock_behavior_t
+    type::UInt8
+    pad0::UInt8
+end
+
+struct xcb_xkb_permament_lock_behavior_iterator_t
+    data::Ptr{xcb_xkb_permament_lock_behavior_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_permament_radio_group_behavior_t
+    type::UInt8
+    group::UInt8
+end
+
+struct xcb_xkb_permament_radio_group_behavior_iterator_t
+    data::Ptr{xcb_xkb_permament_radio_group_behavior_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_permament_overlay_behavior_t
+    type::UInt8
+    key::xcb_keycode_t
+end
+
+struct xcb_xkb_permament_overlay_behavior_iterator_t
+    data::Ptr{xcb_xkb_permament_overlay_behavior_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_behavior_t
+    common::xcb_xkb_common_behavior_t
+end
+
+struct xcb_xkb_behavior_iterator_t
+    data::Ptr{xcb_xkb_behavior_t}
+    rem::Cint
+    index::Cint
+end
+
+@cenum xcb_xkb_behavior_type_t::UInt32 begin
+    XCB_XKB_BEHAVIOR_TYPE_DEFAULT = 0
+    XCB_XKB_BEHAVIOR_TYPE_LOCK = 1
+    XCB_XKB_BEHAVIOR_TYPE_RADIO_GROUP = 2
+    XCB_XKB_BEHAVIOR_TYPE_OVERLAY_1 = 3
+    XCB_XKB_BEHAVIOR_TYPE_OVERLAY_2 = 4
+    XCB_XKB_BEHAVIOR_TYPE_PERMAMENT_LOCK = 129
+    XCB_XKB_BEHAVIOR_TYPE_PERMAMENT_RADIO_GROUP = 130
+    XCB_XKB_BEHAVIOR_TYPE_PERMAMENT_OVERLAY_1 = 131
+    XCB_XKB_BEHAVIOR_TYPE_PERMAMENT_OVERLAY_2 = 132
+end
+
+
+struct xcb_xkb_set_behavior_t
+    keycode::xcb_keycode_t
+    behavior::xcb_xkb_behavior_t
+    pad0::UInt8
+end
+
+struct xcb_xkb_set_behavior_iterator_t
+    data::Ptr{xcb_xkb_set_behavior_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_set_explicit_t
+    keycode::xcb_keycode_t
+    explicit::UInt8
+end
+
+struct xcb_xkb_set_explicit_iterator_t
+    data::Ptr{xcb_xkb_set_explicit_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_key_mod_map_t
+    keycode::xcb_keycode_t
+    mods::UInt8
+end
+
+struct xcb_xkb_key_mod_map_iterator_t
+    data::Ptr{xcb_xkb_key_mod_map_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_key_v_mod_map_t
+    keycode::xcb_keycode_t
+    pad0::UInt8
+    vmods::UInt16
+end
+
+struct xcb_xkb_key_v_mod_map_iterator_t
+    data::Ptr{xcb_xkb_key_v_mod_map_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_kt_set_map_entry_t
+    level::UInt8
+    realMods::UInt8
+    virtualMods::UInt16
+end
+
+struct xcb_xkb_kt_set_map_entry_iterator_t
+    data::Ptr{xcb_xkb_kt_set_map_entry_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_set_key_type_t
+    mask::UInt8
+    realMods::UInt8
+    virtualMods::UInt16
+    numLevels::UInt8
+    nMapEntries::UInt8
+    preserve::UInt8
+    pad0::UInt8
+end
+
+struct xcb_xkb_set_key_type_iterator_t
+    data::Ptr{xcb_xkb_set_key_type_t}
+    rem::Cint
+    index::Cint
+end
+
+const xcb_xkb_string8_t = UInt8
+
+struct xcb_xkb_string8_iterator_t
+    data::Ptr{xcb_xkb_string8_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_outline_t
+    nPoints::UInt8
+    cornerRadius::UInt8
+    pad0::NTuple{2, UInt8}
+end
+
+struct xcb_xkb_outline_iterator_t
+    data::Ptr{xcb_xkb_outline_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_shape_t
+    name::xcb_atom_t
+    nOutlines::UInt8
+    primaryNdx::UInt8
+    approxNdx::UInt8
+    pad0::UInt8
+end
+
+struct xcb_xkb_shape_iterator_t
+    data::Ptr{xcb_xkb_shape_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_key_t
+    name::NTuple{4, xcb_xkb_string8_t}
+    gap::Int16
+    shapeNdx::UInt8
+    colorNdx::UInt8
+end
+
+struct xcb_xkb_key_iterator_t
+    data::Ptr{xcb_xkb_key_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_overlay_key_t
+    over::NTuple{4, xcb_xkb_string8_t}
+    under::NTuple{4, xcb_xkb_string8_t}
+end
+
+struct xcb_xkb_overlay_key_iterator_t
+    data::Ptr{xcb_xkb_overlay_key_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_overlay_row_t
+    rowUnder::UInt8
+    nKeys::UInt8
+    pad0::NTuple{2, UInt8}
+end
+
+struct xcb_xkb_overlay_row_iterator_t
+    data::Ptr{xcb_xkb_overlay_row_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_overlay_t
+    name::xcb_atom_t
+    nRows::UInt8
+    pad0::NTuple{3, UInt8}
+end
+
+struct xcb_xkb_overlay_iterator_t
+    data::Ptr{xcb_xkb_overlay_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_row_t
+    top::Int16
+    left::Int16
+    nKeys::UInt8
+    vertical::UInt8
+    pad0::NTuple{2, UInt8}
+end
+
+struct xcb_xkb_row_iterator_t
+    data::Ptr{xcb_xkb_row_t}
+    rem::Cint
+    index::Cint
+end
+
+@cenum xcb_xkb_doodad_type_t::UInt32 begin
+    XCB_XKB_DOODAD_TYPE_OUTLINE = 1
+    XCB_XKB_DOODAD_TYPE_SOLID = 2
+    XCB_XKB_DOODAD_TYPE_TEXT = 3
+    XCB_XKB_DOODAD_TYPE_INDICATOR = 4
+    XCB_XKB_DOODAD_TYPE_LOGO = 5
+end
+
+
+struct xcb_xkb_listing_t
+    flags::UInt16
+    length::UInt16
+end
+
+struct xcb_xkb_listing_iterator_t
+    data::Ptr{xcb_xkb_listing_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_device_led_info_t
+    ledClass::xcb_xkb_led_class_spec_t
+    ledID::xcb_xkb_id_spec_t
+    namesPresent::UInt32
+    mapsPresent::UInt32
+    physIndicators::UInt32
+    state::UInt32
+end
+
+struct xcb_xkb_device_led_info_iterator_t
+    data::Ptr{xcb_xkb_device_led_info_t}
+    rem::Cint
+    index::Cint
+end
+
+@cenum xcb_xkb_error_t::UInt32 begin
+    XCB_XKB_ERROR_BAD_DEVICE = 255
+    XCB_XKB_ERROR_BAD_CLASS = 254
+    XCB_XKB_ERROR_BAD_ID = 253
+end
+
+
+struct xcb_xkb_keyboard_error_t
+    response_type::UInt8
+    error_code::UInt8
+    sequence::UInt16
+    value::UInt32
+    minorOpcode::UInt16
+    majorOpcode::UInt8
+    pad0::NTuple{21, UInt8}
+end
+
+@cenum xcb_xkb_sa_t::UInt32 begin
+    XCB_XKB_SA_CLEAR_LOCKS = 1
+    XCB_XKB_SA_LATCH_TO_LOCK = 2
+    XCB_XKB_SA_USE_MOD_MAP_MODS = 4
+    XCB_XKB_SA_GROUP_ABSOLUTE = 4
+end
+
+@cenum xcb_xkb_sa_type_t::UInt32 begin
+    XCB_XKB_SA_TYPE_NO_ACTION = 0
+    XCB_XKB_SA_TYPE_SET_MODS = 1
+    XCB_XKB_SA_TYPE_LATCH_MODS = 2
+    XCB_XKB_SA_TYPE_LOCK_MODS = 3
+    XCB_XKB_SA_TYPE_SET_GROUP = 4
+    XCB_XKB_SA_TYPE_LATCH_GROUP = 5
+    XCB_XKB_SA_TYPE_LOCK_GROUP = 6
+    XCB_XKB_SA_TYPE_MOVE_PTR = 7
+    XCB_XKB_SA_TYPE_PTR_BTN = 8
+    XCB_XKB_SA_TYPE_LOCK_PTR_BTN = 9
+    XCB_XKB_SA_TYPE_SET_PTR_DFLT = 10
+    XCB_XKB_SA_TYPE_ISO_LOCK = 11
+    XCB_XKB_SA_TYPE_TERMINATE = 12
+    XCB_XKB_SA_TYPE_SWITCH_SCREEN = 13
+    XCB_XKB_SA_TYPE_SET_CONTROLS = 14
+    XCB_XKB_SA_TYPE_LOCK_CONTROLS = 15
+    XCB_XKB_SA_TYPE_ACTION_MESSAGE = 16
+    XCB_XKB_SA_TYPE_REDIRECT_KEY = 17
+    XCB_XKB_SA_TYPE_DEVICE_BTN = 18
+    XCB_XKB_SA_TYPE_LOCK_DEVICE_BTN = 19
+    XCB_XKB_SA_TYPE_DEVICE_VALUATOR = 20
+end
+
+
+struct xcb_xkb_sa_no_action_t
+    type::UInt8
+    pad0::NTuple{7, UInt8}
+end
+
+struct xcb_xkb_sa_no_action_iterator_t
+    data::Ptr{xcb_xkb_sa_no_action_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_sa_set_mods_t
+    type::UInt8
+    flags::UInt8
+    mask::UInt8
+    realMods::UInt8
+    vmodsHigh::UInt8
+    vmodsLow::UInt8
+    pad0::NTuple{2, UInt8}
+end
+
+struct xcb_xkb_sa_set_mods_iterator_t
+    data::Ptr{xcb_xkb_sa_set_mods_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_sa_latch_mods_t
+    type::UInt8
+    flags::UInt8
+    mask::UInt8
+    realMods::UInt8
+    vmodsHigh::UInt8
+    vmodsLow::UInt8
+    pad0::NTuple{2, UInt8}
+end
+
+struct xcb_xkb_sa_latch_mods_iterator_t
+    data::Ptr{xcb_xkb_sa_latch_mods_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_sa_lock_mods_t
+    type::UInt8
+    flags::UInt8
+    mask::UInt8
+    realMods::UInt8
+    vmodsHigh::UInt8
+    vmodsLow::UInt8
+    pad0::NTuple{2, UInt8}
+end
+
+struct xcb_xkb_sa_lock_mods_iterator_t
+    data::Ptr{xcb_xkb_sa_lock_mods_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_sa_set_group_t
+    type::UInt8
+    flags::UInt8
+    group::Int8
+    pad0::NTuple{5, UInt8}
+end
+
+struct xcb_xkb_sa_set_group_iterator_t
+    data::Ptr{xcb_xkb_sa_set_group_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_sa_latch_group_t
+    type::UInt8
+    flags::UInt8
+    group::Int8
+    pad0::NTuple{5, UInt8}
+end
+
+struct xcb_xkb_sa_latch_group_iterator_t
+    data::Ptr{xcb_xkb_sa_latch_group_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_sa_lock_group_t
+    type::UInt8
+    flags::UInt8
+    group::Int8
+    pad0::NTuple{5, UInt8}
+end
+
+struct xcb_xkb_sa_lock_group_iterator_t
+    data::Ptr{xcb_xkb_sa_lock_group_t}
+    rem::Cint
+    index::Cint
+end
+
+@cenum xcb_xkb_sa_move_ptr_flag_t::UInt32 begin
+    XCB_XKB_SA_MOVE_PTR_FLAG_NO_ACCELERATION = 1
+    XCB_XKB_SA_MOVE_PTR_FLAG_MOVE_ABSOLUTE_X = 2
+    XCB_XKB_SA_MOVE_PTR_FLAG_MOVE_ABSOLUTE_Y = 4
+end
+
+
+struct xcb_xkb_sa_move_ptr_t
+    type::UInt8
+    flags::UInt8
+    xHigh::Int8
+    xLow::UInt8
+    yHigh::Int8
+    yLow::UInt8
+    pad0::NTuple{2, UInt8}
+end
+
+struct xcb_xkb_sa_move_ptr_iterator_t
+    data::Ptr{xcb_xkb_sa_move_ptr_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_sa_ptr_btn_t
+    type::UInt8
+    flags::UInt8
+    count::UInt8
+    button::UInt8
+    pad0::NTuple{4, UInt8}
+end
+
+struct xcb_xkb_sa_ptr_btn_iterator_t
+    data::Ptr{xcb_xkb_sa_ptr_btn_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_sa_lock_ptr_btn_t
+    type::UInt8
+    flags::UInt8
+    pad0::UInt8
+    button::UInt8
+    pad1::NTuple{4, UInt8}
+end
+
+struct xcb_xkb_sa_lock_ptr_btn_iterator_t
+    data::Ptr{xcb_xkb_sa_lock_ptr_btn_t}
+    rem::Cint
+    index::Cint
+end
+
+@cenum xcb_xkb_sa_set_ptr_dflt_flag_t::UInt32 begin
+    XCB_XKB_SA_SET_PTR_DFLT_FLAG_DFLT_BTN_ABSOLUTE = 4
+    XCB_XKB_SA_SET_PTR_DFLT_FLAG_AFFECT_DFLT_BUTTON = 1
+end
+
+
+struct xcb_xkb_sa_set_ptr_dflt_t
+    type::UInt8
+    flags::UInt8
+    affect::UInt8
+    value::Int8
+    pad0::NTuple{4, UInt8}
+end
+
+struct xcb_xkb_sa_set_ptr_dflt_iterator_t
+    data::Ptr{xcb_xkb_sa_set_ptr_dflt_t}
+    rem::Cint
+    index::Cint
+end
+
+@cenum xcb_xkb_sa_iso_lock_flag_t::UInt32 begin
+    XCB_XKB_SA_ISO_LOCK_FLAG_NO_LOCK = 1
+    XCB_XKB_SA_ISO_LOCK_FLAG_NO_UNLOCK = 2
+    XCB_XKB_SA_ISO_LOCK_FLAG_USE_MOD_MAP_MODS = 4
+    XCB_XKB_SA_ISO_LOCK_FLAG_GROUP_ABSOLUTE = 4
+    XCB_XKB_SA_ISO_LOCK_FLAG_ISO_DFLT_IS_GROUP = 8
+end
+
+@cenum xcb_xkb_sa_iso_lock_no_affect_t::UInt32 begin
+    XCB_XKB_SA_ISO_LOCK_NO_AFFECT_CTRLS = 8
+    XCB_XKB_SA_ISO_LOCK_NO_AFFECT_PTR = 16
+    XCB_XKB_SA_ISO_LOCK_NO_AFFECT_GROUP = 32
+    XCB_XKB_SA_ISO_LOCK_NO_AFFECT_MODS = 64
+end
+
+
+struct xcb_xkb_sa_iso_lock_t
+    type::UInt8
+    flags::UInt8
+    mask::UInt8
+    realMods::UInt8
+    group::Int8
+    affect::UInt8
+    vmodsHigh::UInt8
+    vmodsLow::UInt8
+end
+
+struct xcb_xkb_sa_iso_lock_iterator_t
+    data::Ptr{xcb_xkb_sa_iso_lock_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_sa_terminate_t
+    type::UInt8
+    pad0::NTuple{7, UInt8}
+end
+
+struct xcb_xkb_sa_terminate_iterator_t
+    data::Ptr{xcb_xkb_sa_terminate_t}
+    rem::Cint
+    index::Cint
+end
+
+@cenum xcb_xkb_switch_screen_flag_t::UInt32 begin
+    XCB_XKB_SWITCH_SCREEN_FLAG_APPLICATION = 1
+    XCB_XKB_SWITCH_SCREEN_FLAG_ABSOLUTE = 4
+end
+
+
+struct xcb_xkb_sa_switch_screen_t
+    type::UInt8
+    flags::UInt8
+    newScreen::Int8
+    pad0::NTuple{5, UInt8}
+end
+
+struct xcb_xkb_sa_switch_screen_iterator_t
+    data::Ptr{xcb_xkb_sa_switch_screen_t}
+    rem::Cint
+    index::Cint
+end
+
+@cenum xcb_xkb_bool_ctrls_high_t::UInt32 begin
+    XCB_XKB_BOOL_CTRLS_HIGH_ACCESS_X_FEEDBACK = 1
+    XCB_XKB_BOOL_CTRLS_HIGH_AUDIBLE_BELL = 2
+    XCB_XKB_BOOL_CTRLS_HIGH_OVERLAY_1 = 4
+    XCB_XKB_BOOL_CTRLS_HIGH_OVERLAY_2 = 8
+    XCB_XKB_BOOL_CTRLS_HIGH_IGNORE_GROUP_LOCK = 16
+end
+
+@cenum xcb_xkb_bool_ctrls_low_t::UInt32 begin
+    XCB_XKB_BOOL_CTRLS_LOW_REPEAT_KEYS = 1
+    XCB_XKB_BOOL_CTRLS_LOW_SLOW_KEYS = 2
+    XCB_XKB_BOOL_CTRLS_LOW_BOUNCE_KEYS = 4
+    XCB_XKB_BOOL_CTRLS_LOW_STICKY_KEYS = 8
+    XCB_XKB_BOOL_CTRLS_LOW_MOUSE_KEYS = 16
+    XCB_XKB_BOOL_CTRLS_LOW_MOUSE_KEYS_ACCEL = 32
+    XCB_XKB_BOOL_CTRLS_LOW_ACCESS_X_KEYS = 64
+    XCB_XKB_BOOL_CTRLS_LOW_ACCESS_X_TIMEOUT = 128
+end
+
+
+struct xcb_xkb_sa_set_controls_t
+    type::UInt8
+    pad0::NTuple{3, UInt8}
+    boolCtrlsHigh::UInt8
+    boolCtrlsLow::UInt8
+    pad1::NTuple{2, UInt8}
+end
+
+struct xcb_xkb_sa_set_controls_iterator_t
+    data::Ptr{xcb_xkb_sa_set_controls_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_sa_lock_controls_t
+    type::UInt8
+    pad0::NTuple{3, UInt8}
+    boolCtrlsHigh::UInt8
+    boolCtrlsLow::UInt8
+    pad1::NTuple{2, UInt8}
+end
+
+struct xcb_xkb_sa_lock_controls_iterator_t
+    data::Ptr{xcb_xkb_sa_lock_controls_t}
+    rem::Cint
+    index::Cint
+end
+
+@cenum xcb_xkb_action_message_flag_t::UInt32 begin
+    XCB_XKB_ACTION_MESSAGE_FLAG_ON_PRESS = 1
+    XCB_XKB_ACTION_MESSAGE_FLAG_ON_RELEASE = 2
+    XCB_XKB_ACTION_MESSAGE_FLAG_GEN_KEY_EVENT = 4
+end
+
+
+struct xcb_xkb_sa_action_message_t
+    type::UInt8
+    flags::UInt8
+    message::NTuple{6, UInt8}
+end
+
+struct xcb_xkb_sa_action_message_iterator_t
+    data::Ptr{xcb_xkb_sa_action_message_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_sa_redirect_key_t
+    type::UInt8
+    newkey::xcb_keycode_t
+    mask::UInt8
+    realModifiers::UInt8
+    vmodsMaskHigh::UInt8
+    vmodsMaskLow::UInt8
+    vmodsHigh::UInt8
+    vmodsLow::UInt8
+end
+
+struct xcb_xkb_sa_redirect_key_iterator_t
+    data::Ptr{xcb_xkb_sa_redirect_key_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_sa_device_btn_t
+    type::UInt8
+    flags::UInt8
+    count::UInt8
+    button::UInt8
+    device::UInt8
+    pad0::NTuple{3, UInt8}
+end
+
+struct xcb_xkb_sa_device_btn_iterator_t
+    data::Ptr{xcb_xkb_sa_device_btn_t}
+    rem::Cint
+    index::Cint
+end
+
+@cenum xcb_xkb_lock_device_flags_t::UInt32 begin
+    XCB_XKB_LOCK_DEVICE_FLAGS_NO_LOCK = 1
+    XCB_XKB_LOCK_DEVICE_FLAGS_NO_UNLOCK = 2
+end
+
+
+struct xcb_xkb_sa_lock_device_btn_t
+    type::UInt8
+    flags::UInt8
+    pad0::UInt8
+    button::UInt8
+    device::UInt8
+    pad1::NTuple{3, UInt8}
+end
+
+struct xcb_xkb_sa_lock_device_btn_iterator_t
+    data::Ptr{xcb_xkb_sa_lock_device_btn_t}
+    rem::Cint
+    index::Cint
+end
+
+@cenum xcb_xkb_sa_val_what_t::UInt32 begin
+    XCB_XKB_SA_VAL_WHAT_IGNORE_VAL = 0
+    XCB_XKB_SA_VAL_WHAT_SET_VAL_MIN = 1
+    XCB_XKB_SA_VAL_WHAT_SET_VAL_CENTER = 2
+    XCB_XKB_SA_VAL_WHAT_SET_VAL_MAX = 3
+    XCB_XKB_SA_VAL_WHAT_SET_VAL_RELATIVE = 4
+    XCB_XKB_SA_VAL_WHAT_SET_VAL_ABSOLUTE = 5
+end
+
+
+struct xcb_xkb_sa_device_valuator_t
+    type::UInt8
+    device::UInt8
+    val1what::UInt8
+    val1index::UInt8
+    val1value::UInt8
+    val2what::UInt8
+    val2index::UInt8
+    val2value::UInt8
+end
+
+struct xcb_xkb_sa_device_valuator_iterator_t
+    data::Ptr{xcb_xkb_sa_device_valuator_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_si_action_t
+    type::UInt8
+    data::NTuple{7, UInt8}
+end
+
+struct xcb_xkb_si_action_iterator_t
+    data::Ptr{xcb_xkb_si_action_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_sym_interpret_t
+    sym::xcb_keysym_t
+    mods::UInt8
+    match::UInt8
+    virtualMod::UInt8
+    flags::UInt8
+    action::xcb_xkb_si_action_t
+end
+
+struct xcb_xkb_sym_interpret_iterator_t
+    data::Ptr{xcb_xkb_sym_interpret_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_action_t
+    noaction::xcb_xkb_sa_no_action_t
+end
+
+struct xcb_xkb_action_iterator_t
+    data::Ptr{xcb_xkb_action_t}
+    rem::Cint
+    index::Cint
+end
+
+struct xcb_xkb_use_extension_cookie_t
+    sequence::UInt32
+end
+
+struct xcb_xkb_use_extension_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    wantedMajor::UInt16
+    wantedMinor::UInt16
+end
+
+struct xcb_xkb_use_extension_reply_t
+    response_type::UInt8
+    supported::UInt8
+    sequence::UInt16
+    length::UInt32
+    serverMajor::UInt16
+    serverMinor::UInt16
+    pad0::NTuple{20, UInt8}
+end
+
+struct xcb_xkb_select_events_details_t
+    affectNewKeyboard::UInt16
+    newKeyboardDetails::UInt16
+    affectState::UInt16
+    stateDetails::UInt16
+    affectCtrls::UInt32
+    ctrlDetails::UInt32
+    affectIndicatorState::UInt32
+    indicatorStateDetails::UInt32
+    affectIndicatorMap::UInt32
+    indicatorMapDetails::UInt32
+    affectNames::UInt16
+    namesDetails::UInt16
+    affectCompat::UInt8
+    compatDetails::UInt8
+    affectBell::UInt8
+    bellDetails::UInt8
+    affectMsgDetails::UInt8
+    msgDetails::UInt8
+    affectAccessX::UInt16
+    accessXDetails::UInt16
+    affectExtDev::UInt16
+    extdevDetails::UInt16
+end
+
+struct xcb_xkb_select_events_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    affectWhich::UInt16
+    clear::UInt16
+    selectAll::UInt16
+    affectMap::UInt16
+    map::UInt16
+end
+
+struct xcb_xkb_bell_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    bellClass::xcb_xkb_bell_class_spec_t
+    bellID::xcb_xkb_id_spec_t
+    percent::Int8
+    forceSound::UInt8
+    eventOnly::UInt8
+    pad0::UInt8
+    pitch::Int16
+    duration::Int16
+    pad1::NTuple{2, UInt8}
+    name::xcb_atom_t
+    window::xcb_window_t
+end
+
+struct xcb_xkb_get_state_cookie_t
+    sequence::UInt32
+end
+
+struct xcb_xkb_get_state_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    pad0::NTuple{2, UInt8}
+end
+
+struct xcb_xkb_get_state_reply_t
+    response_type::UInt8
+    deviceID::UInt8
+    sequence::UInt16
+    length::UInt32
+    mods::UInt8
+    baseMods::UInt8
+    latchedMods::UInt8
+    lockedMods::UInt8
+    group::UInt8
+    lockedGroup::UInt8
+    baseGroup::Int16
+    latchedGroup::Int16
+    compatState::UInt8
+    grabMods::UInt8
+    compatGrabMods::UInt8
+    lookupMods::UInt8
+    compatLookupMods::UInt8
+    pad0::UInt8
+    ptrBtnState::UInt16
+    pad1::NTuple{6, UInt8}
+end
+
+struct xcb_xkb_latch_lock_state_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    affectModLocks::UInt8
+    modLocks::UInt8
+    lockGroup::UInt8
+    groupLock::UInt8
+    affectModLatches::UInt8
+    pad0::UInt8
+    pad1::UInt8
+    latchGroup::UInt8
+    groupLatch::UInt16
+end
+
+struct xcb_xkb_get_controls_cookie_t
+    sequence::UInt32
+end
+
+struct xcb_xkb_get_controls_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    pad0::NTuple{2, UInt8}
+end
+
+struct xcb_xkb_get_controls_reply_t
+    response_type::UInt8
+    deviceID::UInt8
+    sequence::UInt16
+    length::UInt32
+    mouseKeysDfltBtn::UInt8
+    numGroups::UInt8
+    groupsWrap::UInt8
+    internalModsMask::UInt8
+    ignoreLockModsMask::UInt8
+    internalModsRealMods::UInt8
+    ignoreLockModsRealMods::UInt8
+    pad0::UInt8
+    internalModsVmods::UInt16
+    ignoreLockModsVmods::UInt16
+    repeatDelay::UInt16
+    repeatInterval::UInt16
+    slowKeysDelay::UInt16
+    debounceDelay::UInt16
+    mouseKeysDelay::UInt16
+    mouseKeysInterval::UInt16
+    mouseKeysTimeToMax::UInt16
+    mouseKeysMaxSpeed::UInt16
+    mouseKeysCurve::Int16
+    accessXOption::UInt16
+    accessXTimeout::UInt16
+    accessXTimeoutOptionsMask::UInt16
+    accessXTimeoutOptionsValues::UInt16
+    pad1::NTuple{2, UInt8}
+    accessXTimeoutMask::UInt32
+    accessXTimeoutValues::UInt32
+    enabledControls::UInt32
+    perKeyRepeat::NTuple{32, UInt8}
+end
+
+struct xcb_xkb_set_controls_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    affectInternalRealMods::UInt8
+    internalRealMods::UInt8
+    affectIgnoreLockRealMods::UInt8
+    ignoreLockRealMods::UInt8
+    affectInternalVirtualMods::UInt16
+    internalVirtualMods::UInt16
+    affectIgnoreLockVirtualMods::UInt16
+    ignoreLockVirtualMods::UInt16
+    mouseKeysDfltBtn::UInt8
+    groupsWrap::UInt8
+    accessXOptions::UInt16
+    pad0::NTuple{2, UInt8}
+    affectEnabledControls::UInt32
+    enabledControls::UInt32
+    changeControls::UInt32
+    repeatDelay::UInt16
+    repeatInterval::UInt16
+    slowKeysDelay::UInt16
+    debounceDelay::UInt16
+    mouseKeysDelay::UInt16
+    mouseKeysInterval::UInt16
+    mouseKeysTimeToMax::UInt16
+    mouseKeysMaxSpeed::UInt16
+    mouseKeysCurve::Int16
+    accessXTimeout::UInt16
+    accessXTimeoutMask::UInt32
+    accessXTimeoutValues::UInt32
+    accessXTimeoutOptionsMask::UInt16
+    accessXTimeoutOptionsValues::UInt16
+    perKeyRepeat::NTuple{32, UInt8}
+end
+
+struct xcb_xkb_get_map_cookie_t
+    sequence::UInt32
+end
+
+struct xcb_xkb_get_map_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    full::UInt16
+    partial::UInt16
+    firstType::UInt8
+    nTypes::UInt8
+    firstKeySym::xcb_keycode_t
+    nKeySyms::UInt8
+    firstKeyAction::xcb_keycode_t
+    nKeyActions::UInt8
+    firstKeyBehavior::xcb_keycode_t
+    nKeyBehaviors::UInt8
+    virtualMods::UInt16
+    firstKeyExplicit::xcb_keycode_t
+    nKeyExplicit::UInt8
+    firstModMapKey::xcb_keycode_t
+    nModMapKeys::UInt8
+    firstVModMapKey::xcb_keycode_t
+    nVModMapKeys::UInt8
+    pad0::NTuple{2, UInt8}
+end
+
+struct xcb_xkb_get_map_map_t
+    types_rtrn::Ptr{xcb_xkb_key_type_t}
+    syms_rtrn::Ptr{xcb_xkb_key_sym_map_t}
+    acts_rtrn_count::Ptr{UInt8}
+    pad2::Ptr{UInt8}
+    acts_rtrn_acts::Ptr{xcb_xkb_action_t}
+    behaviors_rtrn::Ptr{xcb_xkb_set_behavior_t}
+    vmods_rtrn::Ptr{UInt8}
+    pad3::Ptr{UInt8}
+    explicit_rtrn::Ptr{xcb_xkb_set_explicit_t}
+    pad4::Ptr{UInt8}
+    modmap_rtrn::Ptr{xcb_xkb_key_mod_map_t}
+    pad5::Ptr{UInt8}
+    vmodmap_rtrn::Ptr{xcb_xkb_key_v_mod_map_t}
+end
+
+struct xcb_xkb_get_map_reply_t
+    response_type::UInt8
+    deviceID::UInt8
+    sequence::UInt16
+    length::UInt32
+    pad0::NTuple{2, UInt8}
+    minKeyCode::xcb_keycode_t
+    maxKeyCode::xcb_keycode_t
+    present::UInt16
+    firstType::UInt8
+    nTypes::UInt8
+    totalTypes::UInt8
+    firstKeySym::xcb_keycode_t
+    totalSyms::UInt16
+    nKeySyms::UInt8
+    firstKeyAction::xcb_keycode_t
+    totalActions::UInt16
+    nKeyActions::UInt8
+    firstKeyBehavior::xcb_keycode_t
+    nKeyBehaviors::UInt8
+    totalKeyBehaviors::UInt8
+    firstKeyExplicit::xcb_keycode_t
+    nKeyExplicit::UInt8
+    totalKeyExplicit::UInt8
+    firstModMapKey::xcb_keycode_t
+    nModMapKeys::UInt8
+    totalModMapKeys::UInt8
+    firstVModMapKey::xcb_keycode_t
+    nVModMapKeys::UInt8
+    totalVModMapKeys::UInt8
+    pad1::UInt8
+    virtualMods::UInt16
+end
+
+struct xcb_xkb_set_map_values_t
+    types::Ptr{xcb_xkb_set_key_type_t}
+    syms::Ptr{xcb_xkb_key_sym_map_t}
+    actionsCount::Ptr{UInt8}
+    actions::Ptr{xcb_xkb_action_t}
+    behaviors::Ptr{xcb_xkb_set_behavior_t}
+    vmods::Ptr{UInt8}
+    explicit::Ptr{xcb_xkb_set_explicit_t}
+    modmap::Ptr{xcb_xkb_key_mod_map_t}
+    vmodmap::Ptr{xcb_xkb_key_v_mod_map_t}
+end
+
+struct xcb_xkb_set_map_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    present::UInt16
+    flags::UInt16
+    minKeyCode::xcb_keycode_t
+    maxKeyCode::xcb_keycode_t
+    firstType::UInt8
+    nTypes::UInt8
+    firstKeySym::xcb_keycode_t
+    nKeySyms::UInt8
+    totalSyms::UInt16
+    firstKeyAction::xcb_keycode_t
+    nKeyActions::UInt8
+    totalActions::UInt16
+    firstKeyBehavior::xcb_keycode_t
+    nKeyBehaviors::UInt8
+    totalKeyBehaviors::UInt8
+    firstKeyExplicit::xcb_keycode_t
+    nKeyExplicit::UInt8
+    totalKeyExplicit::UInt8
+    firstModMapKey::xcb_keycode_t
+    nModMapKeys::UInt8
+    totalModMapKeys::UInt8
+    firstVModMapKey::xcb_keycode_t
+    nVModMapKeys::UInt8
+    totalVModMapKeys::UInt8
+    virtualMods::UInt16
+end
+
+struct xcb_xkb_get_compat_map_cookie_t
+    sequence::UInt32
+end
+
+struct xcb_xkb_get_compat_map_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    groups::UInt8
+    getAllSI::UInt8
+    firstSI::UInt16
+    nSI::UInt16
+end
+
+struct xcb_xkb_get_compat_map_reply_t
+    response_type::UInt8
+    deviceID::UInt8
+    sequence::UInt16
+    length::UInt32
+    groupsRtrn::UInt8
+    pad0::UInt8
+    firstSIRtrn::UInt16
+    nSIRtrn::UInt16
+    nTotalSI::UInt16
+    pad1::NTuple{16, UInt8}
+end
+
+struct xcb_xkb_set_compat_map_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    pad0::UInt8
+    recomputeActions::UInt8
+    truncateSI::UInt8
+    groups::UInt8
+    firstSI::UInt16
+    nSI::UInt16
+    pad1::NTuple{2, UInt8}
+end
+
+struct xcb_xkb_get_indicator_state_cookie_t
+    sequence::UInt32
+end
+
+struct xcb_xkb_get_indicator_state_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    pad0::NTuple{2, UInt8}
+end
+
+struct xcb_xkb_get_indicator_state_reply_t
+    response_type::UInt8
+    deviceID::UInt8
+    sequence::UInt16
+    length::UInt32
+    state::UInt32
+    pad0::NTuple{20, UInt8}
+end
+
+struct xcb_xkb_get_indicator_map_cookie_t
+    sequence::UInt32
+end
+
+struct xcb_xkb_get_indicator_map_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    pad0::NTuple{2, UInt8}
+    which::UInt32
+end
+
+struct xcb_xkb_get_indicator_map_reply_t
+    response_type::UInt8
+    deviceID::UInt8
+    sequence::UInt16
+    length::UInt32
+    which::UInt32
+    realIndicators::UInt32
+    nIndicators::UInt8
+    pad0::NTuple{15, UInt8}
+end
+
+struct xcb_xkb_set_indicator_map_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    pad0::NTuple{2, UInt8}
+    which::UInt32
+end
+
+struct xcb_xkb_get_named_indicator_cookie_t
+    sequence::UInt32
+end
+
+struct xcb_xkb_get_named_indicator_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    ledClass::xcb_xkb_led_class_spec_t
+    ledID::xcb_xkb_id_spec_t
+    pad0::NTuple{2, UInt8}
+    indicator::xcb_atom_t
+end
+
+struct xcb_xkb_get_named_indicator_reply_t
+    response_type::UInt8
+    deviceID::UInt8
+    sequence::UInt16
+    length::UInt32
+    indicator::xcb_atom_t
+    found::UInt8
+    on::UInt8
+    realIndicator::UInt8
+    ndx::UInt8
+    map_flags::UInt8
+    map_whichGroups::UInt8
+    map_groups::UInt8
+    map_whichMods::UInt8
+    map_mods::UInt8
+    map_realMods::UInt8
+    map_vmod::UInt16
+    map_ctrls::UInt32
+    supported::UInt8
+    pad0::NTuple{3, UInt8}
+end
+
+struct xcb_xkb_set_named_indicator_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    ledClass::xcb_xkb_led_class_spec_t
+    ledID::xcb_xkb_id_spec_t
+    pad0::NTuple{2, UInt8}
+    indicator::xcb_atom_t
+    setState::UInt8
+    on::UInt8
+    setMap::UInt8
+    createMap::UInt8
+    pad1::UInt8
+    map_flags::UInt8
+    map_whichGroups::UInt8
+    map_groups::UInt8
+    map_whichMods::UInt8
+    map_realMods::UInt8
+    map_vmods::UInt16
+    map_ctrls::UInt32
+end
+
+struct xcb_xkb_get_names_cookie_t
+    sequence::UInt32
+end
+
+struct xcb_xkb_get_names_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    pad0::NTuple{2, UInt8}
+    which::UInt32
+end
+
+struct xcb_xkb_get_names_value_list_t
+    keycodesName::xcb_atom_t
+    geometryName::xcb_atom_t
+    symbolsName::xcb_atom_t
+    physSymbolsName::xcb_atom_t
+    typesName::xcb_atom_t
+    compatName::xcb_atom_t
+    typeNames::Ptr{xcb_atom_t}
+    nLevelsPerType::Ptr{UInt8}
+    pad1::Ptr{UInt8}
+    ktLevelNames::Ptr{xcb_atom_t}
+    indicatorNames::Ptr{xcb_atom_t}
+    virtualModNames::Ptr{xcb_atom_t}
+    groups::Ptr{xcb_atom_t}
+    keyNames::Ptr{xcb_xkb_key_name_t}
+    keyAliases::Ptr{xcb_xkb_key_alias_t}
+    radioGroupNames::Ptr{xcb_atom_t}
+end
+
+struct xcb_xkb_get_names_reply_t
+    response_type::UInt8
+    deviceID::UInt8
+    sequence::UInt16
+    length::UInt32
+    which::UInt32
+    minKeyCode::xcb_keycode_t
+    maxKeyCode::xcb_keycode_t
+    nTypes::UInt8
+    groupNames::UInt8
+    virtualMods::UInt16
+    firstKey::xcb_keycode_t
+    nKeys::UInt8
+    indicators::UInt32
+    nRadioGroups::UInt8
+    nKeyAliases::UInt8
+    nKTLevels::UInt16
+    pad0::NTuple{4, UInt8}
+end
+
+struct xcb_xkb_set_names_values_t
+    keycodesName::xcb_atom_t
+    geometryName::xcb_atom_t
+    symbolsName::xcb_atom_t
+    physSymbolsName::xcb_atom_t
+    typesName::xcb_atom_t
+    compatName::xcb_atom_t
+    typeNames::Ptr{xcb_atom_t}
+    nLevelsPerType::Ptr{UInt8}
+    ktLevelNames::Ptr{xcb_atom_t}
+    indicatorNames::Ptr{xcb_atom_t}
+    virtualModNames::Ptr{xcb_atom_t}
+    groups::Ptr{xcb_atom_t}
+    keyNames::Ptr{xcb_xkb_key_name_t}
+    keyAliases::Ptr{xcb_xkb_key_alias_t}
+    radioGroupNames::Ptr{xcb_atom_t}
+end
+
+struct xcb_xkb_set_names_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    virtualMods::UInt16
+    which::UInt32
+    firstType::UInt8
+    nTypes::UInt8
+    firstKTLevelt::UInt8
+    nKTLevels::UInt8
+    indicators::UInt32
+    groupNames::UInt8
+    nRadioGroups::UInt8
+    firstKey::xcb_keycode_t
+    nKeys::UInt8
+    nKeyAliases::UInt8
+    pad0::UInt8
+    totalKTLevelNames::UInt16
+end
+
+struct xcb_xkb_per_client_flags_cookie_t
+    sequence::UInt32
+end
+
+struct xcb_xkb_per_client_flags_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    pad0::NTuple{2, UInt8}
+    change::UInt32
+    value::UInt32
+    ctrlsToChange::UInt32
+    autoCtrls::UInt32
+    autoCtrlsValues::UInt32
+end
+
+struct xcb_xkb_per_client_flags_reply_t
+    response_type::UInt8
+    deviceID::UInt8
+    sequence::UInt16
+    length::UInt32
+    supported::UInt32
+    value::UInt32
+    autoCtrls::UInt32
+    autoCtrlsValues::UInt32
+    pad0::NTuple{8, UInt8}
+end
+
+struct xcb_xkb_list_components_cookie_t
+    sequence::UInt32
+end
+
+struct xcb_xkb_list_components_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    maxNames::UInt16
+end
+
+struct xcb_xkb_list_components_reply_t
+    response_type::UInt8
+    deviceID::UInt8
+    sequence::UInt16
+    length::UInt32
+    nKeymaps::UInt16
+    nKeycodes::UInt16
+    nTypes::UInt16
+    nCompatMaps::UInt16
+    nSymbols::UInt16
+    nGeometries::UInt16
+    extra::UInt16
+    pad0::NTuple{10, UInt8}
+end
+
+struct xcb_xkb_get_kbd_by_name_cookie_t
+    sequence::UInt32
+end
+
+struct xcb_xkb_get_kbd_by_name_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    need::UInt16
+    want::UInt16
+    load::UInt8
+    pad0::UInt8
+end
+
+struct xcb_xkb_get_kbd_by_name_replies_types_map_t
+    types_rtrn::Ptr{xcb_xkb_key_type_t}
+    syms_rtrn::Ptr{xcb_xkb_key_sym_map_t}
+    acts_rtrn_count::Ptr{UInt8}
+    acts_rtrn_acts::Ptr{xcb_xkb_action_t}
+    behaviors_rtrn::Ptr{xcb_xkb_set_behavior_t}
+    vmods_rtrn::Ptr{UInt8}
+    explicit_rtrn::Ptr{xcb_xkb_set_explicit_t}
+    modmap_rtrn::Ptr{xcb_xkb_key_mod_map_t}
+    vmodmap_rtrn::Ptr{xcb_xkb_key_v_mod_map_t}
+end
+
+struct xcb_xkb_get_kbd_by_name_replies_key_names_value_list_t
+    keycodesName::xcb_atom_t
+    geometryName::xcb_atom_t
+    symbolsName::xcb_atom_t
+    physSymbolsName::xcb_atom_t
+    typesName::xcb_atom_t
+    compatName::xcb_atom_t
+    typeNames::Ptr{xcb_atom_t}
+    nLevelsPerType::Ptr{UInt8}
+    ktLevelNames::Ptr{xcb_atom_t}
+    indicatorNames::Ptr{xcb_atom_t}
+    virtualModNames::Ptr{xcb_atom_t}
+    groups::Ptr{xcb_atom_t}
+    keyNames::Ptr{xcb_xkb_key_name_t}
+    keyAliases::Ptr{xcb_xkb_key_alias_t}
+    radioGroupNames::Ptr{xcb_atom_t}
+end
+
+struct ANONYMOUS1_types
+    getmap_type::UInt8
+    typeDeviceID::UInt8
+    getmap_sequence::UInt16
+    getmap_length::UInt32
+    pad1::NTuple{2, UInt8}
+    typeMinKeyCode::xcb_keycode_t
+    typeMaxKeyCode::xcb_keycode_t
+    present::UInt16
+    firstType::UInt8
+    nTypes::UInt8
+    totalTypes::UInt8
+    firstKeySym::xcb_keycode_t
+    totalSyms::UInt16
+    nKeySyms::UInt8
+    firstKeyAction::xcb_keycode_t
+    totalActions::UInt16
+    nKeyActions::UInt8
+    firstKeyBehavior::xcb_keycode_t
+    nKeyBehaviors::UInt8
+    totalKeyBehaviors::UInt8
+    firstKeyExplicit::xcb_keycode_t
+    nKeyExplicit::UInt8
+    totalKeyExplicit::UInt8
+    firstModMapKey::xcb_keycode_t
+    nModMapKeys::UInt8
+    totalModMapKeys::UInt8
+    firstVModMapKey::xcb_keycode_t
+    nVModMapKeys::UInt8
+    totalVModMapKeys::UInt8
+    pad2::UInt8
+    virtualMods::UInt16
+    map::xcb_xkb_get_kbd_by_name_replies_types_map_t
+end
+
+struct ANONYMOUS2_compat_map
+    compatmap_type::UInt8
+    compatDeviceID::UInt8
+    compatmap_sequence::UInt16
+    compatmap_length::UInt32
+    groupsRtrn::UInt8
+    pad7::UInt8
+    firstSIRtrn::UInt16
+    nSIRtrn::UInt16
+    nTotalSI::UInt16
+    pad8::NTuple{16, UInt8}
+    si_rtrn::Ptr{xcb_xkb_sym_interpret_t}
+    group_rtrn::Ptr{xcb_xkb_mod_def_t}
+end
+
+struct ANONYMOUS3_indicator_maps
+    indicatormap_type::UInt8
+    indicatorDeviceID::UInt8
+    indicatormap_sequence::UInt16
+    indicatormap_length::UInt32
+    which::UInt32
+    realIndicators::UInt32
+    nIndicators::UInt8
+    pad9::NTuple{15, UInt8}
+    maps::Ptr{xcb_xkb_indicator_map_t}
+end
+
+struct ANONYMOUS4_key_names
+    keyname_type::UInt8
+    keyDeviceID::UInt8
+    keyname_sequence::UInt16
+    keyname_length::UInt32
+    which::UInt32
+    keyMinKeyCode::xcb_keycode_t
+    keyMaxKeyCode::xcb_keycode_t
+    nTypes::UInt8
+    groupNames::UInt8
+    virtualMods::UInt16
+    firstKey::xcb_keycode_t
+    nKeys::UInt8
+    indicators::UInt32
+    nRadioGroups::UInt8
+    nKeyAliases::UInt8
+    nKTLevels::UInt16
+    pad10::NTuple{4, UInt8}
+    valueList::xcb_xkb_get_kbd_by_name_replies_key_names_value_list_t
+end
+
+struct ANONYMOUS5_geometry
+    geometry_type::UInt8
+    geometryDeviceID::UInt8
+    geometry_sequence::UInt16
+    geometry_length::UInt32
+    name::xcb_atom_t
+    geometryFound::UInt8
+    pad12::UInt8
+    widthMM::UInt16
+    heightMM::UInt16
+    nProperties::UInt16
+    nColors::UInt16
+    nShapes::UInt16
+    nSections::UInt16
+    nDoodads::UInt16
+    nKeyAliases::UInt16
+    baseColorNdx::UInt8
+    labelColorNdx::UInt8
+    labelFont::Ptr{xcb_xkb_counted_string_16_t}
+end
+
+struct xcb_xkb_get_kbd_by_name_replies_t
+    types::ANONYMOUS1_types
+    compat_map::ANONYMOUS2_compat_map
+    indicator_maps::ANONYMOUS3_indicator_maps
+    key_names::ANONYMOUS4_key_names
+    geometry::ANONYMOUS5_geometry
+end
+
+struct xcb_xkb_get_kbd_by_name_reply_t
+    response_type::UInt8
+    deviceID::UInt8
+    sequence::UInt16
+    length::UInt32
+    minKeyCode::xcb_keycode_t
+    maxKeyCode::xcb_keycode_t
+    loaded::UInt8
+    newKeyboard::UInt8
+    found::UInt16
+    reported::UInt16
+    pad0::NTuple{16, UInt8}
+end
+
+struct xcb_xkb_get_device_info_cookie_t
+    sequence::UInt32
+end
+
+struct xcb_xkb_get_device_info_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    wanted::UInt16
+    allButtons::UInt8
+    firstButton::UInt8
+    nButtons::UInt8
+    pad0::UInt8
+    ledClass::xcb_xkb_led_class_spec_t
+    ledID::xcb_xkb_id_spec_t
+end
+
+struct xcb_xkb_get_device_info_reply_t
+    response_type::UInt8
+    deviceID::UInt8
+    sequence::UInt16
+    length::UInt32
+    present::UInt16
+    supported::UInt16
+    unsupported::UInt16
+    nDeviceLedFBs::UInt16
+    firstBtnWanted::UInt8
+    nBtnsWanted::UInt8
+    firstBtnRtrn::UInt8
+    nBtnsRtrn::UInt8
+    totalBtns::UInt8
+    hasOwnState::UInt8
+    dfltKbdFB::UInt16
+    dfltLedFB::UInt16
+    pad0::NTuple{2, UInt8}
+    devType::xcb_atom_t
+    nameLen::UInt16
+end
+
+struct xcb_xkb_set_device_info_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    deviceSpec::xcb_xkb_device_spec_t
+    firstBtn::UInt8
+    nBtns::UInt8
+    change::UInt16
+    nDeviceLedFBs::UInt16
+end
+
+struct xcb_xkb_set_debugging_flags_cookie_t
+    sequence::UInt32
+end
+
+struct xcb_xkb_set_debugging_flags_request_t
+    major_opcode::UInt8
+    minor_opcode::UInt8
+    length::UInt16
+    msgLength::UInt16
+    pad0::NTuple{2, UInt8}
+    affectFlags::UInt32
+    flags::UInt32
+    affectCtrls::UInt32
+    ctrls::UInt32
+end
+
+struct xcb_xkb_set_debugging_flags_reply_t
+    response_type::UInt8
+    pad0::UInt8
+    sequence::UInt16
+    length::UInt32
+    currentFlags::UInt32
+    currentCtrls::UInt32
+    supportedFlags::UInt32
+    supportedCtrls::UInt32
+    pad1::NTuple{8, UInt8}
+end
+
+struct xcb_xkb_new_keyboard_notify_event_t
+    response_type::UInt8
+    xkbType::UInt8
+    sequence::UInt16
+    time::xcb_timestamp_t
+    deviceID::UInt8
+    oldDeviceID::UInt8
+    minKeyCode::xcb_keycode_t
+    maxKeyCode::xcb_keycode_t
+    oldMinKeyCode::xcb_keycode_t
+    oldMaxKeyCode::xcb_keycode_t
+    requestMajor::UInt8
+    requestMinor::UInt8
+    changed::UInt16
+    pad0::NTuple{14, UInt8}
+end
+
+struct xcb_xkb_map_notify_event_t
+    response_type::UInt8
+    xkbType::UInt8
+    sequence::UInt16
+    time::xcb_timestamp_t
+    deviceID::UInt8
+    ptrBtnActions::UInt8
+    changed::UInt16
+    minKeyCode::xcb_keycode_t
+    maxKeyCode::xcb_keycode_t
+    firstType::UInt8
+    nTypes::UInt8
+    firstKeySym::xcb_keycode_t
+    nKeySyms::UInt8
+    firstKeyAct::xcb_keycode_t
+    nKeyActs::UInt8
+    firstKeyBehavior::xcb_keycode_t
+    nKeyBehavior::UInt8
+    firstKeyExplicit::xcb_keycode_t
+    nKeyExplicit::UInt8
+    firstModMapKey::xcb_keycode_t
+    nModMapKeys::UInt8
+    firstVModMapKey::xcb_keycode_t
+    nVModMapKeys::UInt8
+    virtualMods::UInt16
+    pad0::NTuple{2, UInt8}
+end
+
+struct xcb_xkb_state_notify_event_t
+    response_type::UInt8
+    xkbType::UInt8
+    sequence::UInt16
+    time::xcb_timestamp_t
+    deviceID::UInt8
+    mods::UInt8
+    baseMods::UInt8
+    latchedMods::UInt8
+    lockedMods::UInt8
+    group::UInt8
+    baseGroup::Int16
+    latchedGroup::Int16
+    lockedGroup::UInt8
+    compatState::UInt8
+    grabMods::UInt8
+    compatGrabMods::UInt8
+    lookupMods::UInt8
+    compatLoockupMods::UInt8
+    ptrBtnState::UInt16
+    changed::UInt16
+    keycode::xcb_keycode_t
+    eventType::UInt8
+    requestMajor::UInt8
+    requestMinor::UInt8
+end
+
+struct xcb_xkb_controls_notify_event_t
+    response_type::UInt8
+    xkbType::UInt8
+    sequence::UInt16
+    time::xcb_timestamp_t
+    deviceID::UInt8
+    numGroups::UInt8
+    pad0::NTuple{2, UInt8}
+    changedControls::UInt32
+    enabledControls::UInt32
+    enabledControlChanges::UInt32
+    keycode::xcb_keycode_t
+    eventType::UInt8
+    requestMajor::UInt8
+    requestMinor::UInt8
+    pad1::NTuple{4, UInt8}
+end
+
+struct xcb_xkb_indicator_state_notify_event_t
+    response_type::UInt8
+    xkbType::UInt8
+    sequence::UInt16
+    time::xcb_timestamp_t
+    deviceID::UInt8
+    pad0::NTuple{3, UInt8}
+    state::UInt32
+    stateChanged::UInt32
+    pad1::NTuple{12, UInt8}
+end
+
+struct xcb_xkb_indicator_map_notify_event_t
+    response_type::UInt8
+    xkbType::UInt8
+    sequence::UInt16
+    time::xcb_timestamp_t
+    deviceID::UInt8
+    pad0::NTuple{3, UInt8}
+    state::UInt32
+    mapChanged::UInt32
+    pad1::NTuple{12, UInt8}
+end
+
+struct xcb_xkb_names_notify_event_t
+    response_type::UInt8
+    xkbType::UInt8
+    sequence::UInt16
+    time::xcb_timestamp_t
+    deviceID::UInt8
+    pad0::UInt8
+    changed::UInt16
+    firstType::UInt8
+    nTypes::UInt8
+    firstLevelName::UInt8
+    nLevelNames::UInt8
+    pad1::UInt8
+    nRadioGroups::UInt8
+    nKeyAliases::UInt8
+    changedGroupNames::UInt8
+    changedVirtualMods::UInt16
+    firstKey::xcb_keycode_t
+    nKeys::UInt8
+    changedIndicators::UInt32
+    pad2::NTuple{4, UInt8}
+end
+
+struct xcb_xkb_compat_map_notify_event_t
+    response_type::UInt8
+    xkbType::UInt8
+    sequence::UInt16
+    time::xcb_timestamp_t
+    deviceID::UInt8
+    changedGroups::UInt8
+    firstSI::UInt16
+    nSI::UInt16
+    nTotalSI::UInt16
+    pad0::NTuple{16, UInt8}
+end
+
+struct xcb_xkb_bell_notify_event_t
+    response_type::UInt8
+    xkbType::UInt8
+    sequence::UInt16
+    time::xcb_timestamp_t
+    deviceID::UInt8
+    bellClass::UInt8
+    bellID::UInt8
+    percent::UInt8
+    pitch::UInt16
+    duration::UInt16
+    name::xcb_atom_t
+    window::xcb_window_t
+    eventOnly::UInt8
+    pad0::NTuple{7, UInt8}
+end
+
+struct xcb_xkb_action_message_event_t
+    response_type::UInt8
+    xkbType::UInt8
+    sequence::UInt16
+    time::xcb_timestamp_t
+    deviceID::UInt8
+    keycode::xcb_keycode_t
+    press::UInt8
+    keyEventFollows::UInt8
+    mods::UInt8
+    group::UInt8
+    message::NTuple{8, xcb_xkb_string8_t}
+    pad0::NTuple{10, UInt8}
+end
+
+struct xcb_xkb_access_x_notify_event_t
+    response_type::UInt8
+    xkbType::UInt8
+    sequence::UInt16
+    time::xcb_timestamp_t
+    deviceID::UInt8
+    keycode::xcb_keycode_t
+    detailt::UInt16
+    slowKeysDelay::UInt16
+    debounceDelay::UInt16
+    pad0::NTuple{16, UInt8}
+end
+
+struct xcb_xkb_extension_device_notify_event_t
+    response_type::UInt8
+    xkbType::UInt8
+    sequence::UInt16
+    time::xcb_timestamp_t
+    deviceID::UInt8
+    pad0::UInt8
+    reason::UInt16
+    ledClass::UInt16
+    ledID::UInt16
+    ledsDefined::UInt32
+    ledState::UInt32
+    firstButton::UInt8
+    nButtons::UInt8
+    supported::UInt16
+    unsupported::UInt16
+    pad1::NTuple{2, UInt8}
+end
+
 const _XCBKeySymbols = Cvoid
 const xcb_key_symbols_t = _XCBKeySymbols

--- a/gen/xkb_api.jl
+++ b/gen/xkb_api.jl
@@ -1,0 +1,291 @@
+# Julia wrapper for header: xkbcommon.h
+# Automatically generated using Clang.jl
+
+
+function xkb_keysym_get_name(keysym, buffer, size)
+    ccall((:xkb_keysym_get_name, libxkbcommon), Cint, (xkb_keysym_t, Cstring, Cint), keysym, buffer, size)
+end
+
+function xkb_keysym_from_name(name, flags)
+    ccall((:xkb_keysym_from_name, libxkbcommon), xkb_keysym_t, (Cstring, xkb_keysym_flags), name, flags)
+end
+
+function xkb_keysym_to_utf8(keysym, buffer, size)
+    ccall((:xkb_keysym_to_utf8, libxkbcommon), Cint, (xkb_keysym_t, Cstring, Cint), keysym, buffer, size)
+end
+
+function xkb_keysym_to_utf32(keysym)
+    ccall((:xkb_keysym_to_utf32, libxkbcommon), UInt32, (xkb_keysym_t,), keysym)
+end
+
+function xkb_keysym_to_upper(ks)
+    ccall((:xkb_keysym_to_upper, libxkbcommon), xkb_keysym_t, (xkb_keysym_t,), ks)
+end
+
+function xkb_keysym_to_lower(ks)
+    ccall((:xkb_keysym_to_lower, libxkbcommon), xkb_keysym_t, (xkb_keysym_t,), ks)
+end
+
+function xkb_context_new(flags)
+    ccall((:xkb_context_new, libxkbcommon), Ptr{xkb_context}, (xkb_context_flags,), flags)
+end
+
+function xkb_context_ref(context)
+    ccall((:xkb_context_ref, libxkbcommon), Ptr{xkb_context}, (Ptr{xkb_context},), context)
+end
+
+function xkb_context_unref(context)
+    ccall((:xkb_context_unref, libxkbcommon), Cvoid, (Ptr{xkb_context},), context)
+end
+
+function xkb_context_set_user_data(context, user_data)
+    ccall((:xkb_context_set_user_data, libxkbcommon), Cvoid, (Ptr{xkb_context}, Ptr{Cvoid}), context, user_data)
+end
+
+function xkb_context_get_user_data(context)
+    ccall((:xkb_context_get_user_data, libxkbcommon), Ptr{Cvoid}, (Ptr{xkb_context},), context)
+end
+
+function xkb_context_include_path_append(context, path)
+    ccall((:xkb_context_include_path_append, libxkbcommon), Cint, (Ptr{xkb_context}, Cstring), context, path)
+end
+
+function xkb_context_include_path_append_default(context)
+    ccall((:xkb_context_include_path_append_default, libxkbcommon), Cint, (Ptr{xkb_context},), context)
+end
+
+function xkb_context_include_path_reset_defaults(context)
+    ccall((:xkb_context_include_path_reset_defaults, libxkbcommon), Cint, (Ptr{xkb_context},), context)
+end
+
+function xkb_context_include_path_clear(context)
+    ccall((:xkb_context_include_path_clear, libxkbcommon), Cvoid, (Ptr{xkb_context},), context)
+end
+
+function xkb_context_num_include_paths(context)
+    ccall((:xkb_context_num_include_paths, libxkbcommon), UInt32, (Ptr{xkb_context},), context)
+end
+
+function xkb_context_include_path_get(context, index)
+    ccall((:xkb_context_include_path_get, libxkbcommon), Cstring, (Ptr{xkb_context}, UInt32), context, index)
+end
+
+function xkb_context_set_log_level(context, level)
+    ccall((:xkb_context_set_log_level, libxkbcommon), Cvoid, (Ptr{xkb_context}, xkb_log_level), context, level)
+end
+
+function xkb_context_get_log_level(context)
+    ccall((:xkb_context_get_log_level, libxkbcommon), xkb_log_level, (Ptr{xkb_context},), context)
+end
+
+function xkb_context_set_log_verbosity(context, verbosity)
+    ccall((:xkb_context_set_log_verbosity, libxkbcommon), Cvoid, (Ptr{xkb_context}, Cint), context, verbosity)
+end
+
+function xkb_context_get_log_verbosity(context)
+    ccall((:xkb_context_get_log_verbosity, libxkbcommon), Cint, (Ptr{xkb_context},), context)
+end
+
+function xkb_context_set_log_fn(context, log_fn)
+    ccall((:xkb_context_set_log_fn, libxkbcommon), Cvoid, (Ptr{xkb_context}, Ptr{Cvoid}), context, log_fn)
+end
+
+function xkb_keymap_new_from_names(context, names, flags)
+    ccall((:xkb_keymap_new_from_names, libxkbcommon), Ptr{xkb_keymap}, (Ptr{xkb_context}, Ptr{xkb_rule_names}, xkb_keymap_compile_flags), context, names, flags)
+end
+
+function xkb_keymap_new_from_file(context, file, format, flags)
+    ccall((:xkb_keymap_new_from_file, libxkbcommon), Ptr{xkb_keymap}, (Ptr{xkb_context}, Ptr{FILE}, xkb_keymap_format, xkb_keymap_compile_flags), context, file, format, flags)
+end
+
+function xkb_keymap_new_from_string(context, string, format, flags)
+    ccall((:xkb_keymap_new_from_string, libxkbcommon), Ptr{xkb_keymap}, (Ptr{xkb_context}, Cstring, xkb_keymap_format, xkb_keymap_compile_flags), context, string, format, flags)
+end
+
+function xkb_keymap_new_from_buffer(context, buffer, length, format, flags)
+    ccall((:xkb_keymap_new_from_buffer, libxkbcommon), Ptr{xkb_keymap}, (Ptr{xkb_context}, Cstring, Cint, xkb_keymap_format, xkb_keymap_compile_flags), context, buffer, length, format, flags)
+end
+
+function xkb_keymap_ref(keymap)
+    ccall((:xkb_keymap_ref, libxkbcommon), Ptr{xkb_keymap}, (Ptr{xkb_keymap},), keymap)
+end
+
+function xkb_keymap_unref(keymap)
+    ccall((:xkb_keymap_unref, libxkbcommon), Cvoid, (Ptr{xkb_keymap},), keymap)
+end
+
+function xkb_keymap_get_as_string(keymap, format)
+    ccall((:xkb_keymap_get_as_string, libxkbcommon), Cstring, (Ptr{xkb_keymap}, xkb_keymap_format), keymap, format)
+end
+
+function xkb_keymap_min_keycode(keymap)
+    ccall((:xkb_keymap_min_keycode, libxkbcommon), xkb_keycode_t, (Ptr{xkb_keymap},), keymap)
+end
+
+function xkb_keymap_max_keycode(keymap)
+    ccall((:xkb_keymap_max_keycode, libxkbcommon), xkb_keycode_t, (Ptr{xkb_keymap},), keymap)
+end
+
+function xkb_keymap_key_for_each(keymap, iter, data)
+    ccall((:xkb_keymap_key_for_each, libxkbcommon), Cvoid, (Ptr{xkb_keymap}, xkb_keymap_key_iter_t, Ptr{Cvoid}), keymap, iter, data)
+end
+
+function xkb_keymap_key_get_name(keymap, key)
+    ccall((:xkb_keymap_key_get_name, libxkbcommon), Cstring, (Ptr{xkb_keymap}, xkb_keycode_t), keymap, key)
+end
+
+function xkb_keymap_key_by_name(keymap, name)
+    ccall((:xkb_keymap_key_by_name, libxkbcommon), xkb_keycode_t, (Ptr{xkb_keymap}, Cstring), keymap, name)
+end
+
+function xkb_keymap_num_mods(keymap)
+    ccall((:xkb_keymap_num_mods, libxkbcommon), xkb_mod_index_t, (Ptr{xkb_keymap},), keymap)
+end
+
+function xkb_keymap_mod_get_name(keymap, idx)
+    ccall((:xkb_keymap_mod_get_name, libxkbcommon), Cstring, (Ptr{xkb_keymap}, xkb_mod_index_t), keymap, idx)
+end
+
+function xkb_keymap_mod_get_index(keymap, name)
+    ccall((:xkb_keymap_mod_get_index, libxkbcommon), xkb_mod_index_t, (Ptr{xkb_keymap}, Cstring), keymap, name)
+end
+
+function xkb_keymap_num_layouts(keymap)
+    ccall((:xkb_keymap_num_layouts, libxkbcommon), xkb_layout_index_t, (Ptr{xkb_keymap},), keymap)
+end
+
+function xkb_keymap_layout_get_name(keymap, idx)
+    ccall((:xkb_keymap_layout_get_name, libxkbcommon), Cstring, (Ptr{xkb_keymap}, xkb_layout_index_t), keymap, idx)
+end
+
+function xkb_keymap_layout_get_index(keymap, name)
+    ccall((:xkb_keymap_layout_get_index, libxkbcommon), xkb_layout_index_t, (Ptr{xkb_keymap}, Cstring), keymap, name)
+end
+
+function xkb_keymap_num_leds(keymap)
+    ccall((:xkb_keymap_num_leds, libxkbcommon), xkb_led_index_t, (Ptr{xkb_keymap},), keymap)
+end
+
+function xkb_keymap_led_get_name(keymap, idx)
+    ccall((:xkb_keymap_led_get_name, libxkbcommon), Cstring, (Ptr{xkb_keymap}, xkb_led_index_t), keymap, idx)
+end
+
+function xkb_keymap_led_get_index(keymap, name)
+    ccall((:xkb_keymap_led_get_index, libxkbcommon), xkb_led_index_t, (Ptr{xkb_keymap}, Cstring), keymap, name)
+end
+
+function xkb_keymap_num_layouts_for_key(keymap, key)
+    ccall((:xkb_keymap_num_layouts_for_key, libxkbcommon), xkb_layout_index_t, (Ptr{xkb_keymap}, xkb_keycode_t), keymap, key)
+end
+
+function xkb_keymap_num_levels_for_key(keymap, key, layout)
+    ccall((:xkb_keymap_num_levels_for_key, libxkbcommon), xkb_level_index_t, (Ptr{xkb_keymap}, xkb_keycode_t, xkb_layout_index_t), keymap, key, layout)
+end
+
+function xkb_keymap_key_get_syms_by_level(keymap, key, layout, level, syms_out)
+    ccall((:xkb_keymap_key_get_syms_by_level, libxkbcommon), Cint, (Ptr{xkb_keymap}, xkb_keycode_t, xkb_layout_index_t, xkb_level_index_t, Ptr{Ptr{xkb_keysym_t}}), keymap, key, layout, level, syms_out)
+end
+
+function xkb_keymap_key_repeats(keymap, key)
+    ccall((:xkb_keymap_key_repeats, libxkbcommon), Cint, (Ptr{xkb_keymap}, xkb_keycode_t), keymap, key)
+end
+
+function xkb_state_new(keymap)
+    ccall((:xkb_state_new, libxkbcommon), Ptr{xkb_state}, (Ptr{xkb_keymap},), keymap)
+end
+
+function xkb_state_ref(state)
+    ccall((:xkb_state_ref, libxkbcommon), Ptr{xkb_state}, (Ptr{xkb_state},), state)
+end
+
+function xkb_state_unref(state)
+    ccall((:xkb_state_unref, libxkbcommon), Cvoid, (Ptr{xkb_state},), state)
+end
+
+function xkb_state_get_keymap(state)
+    ccall((:xkb_state_get_keymap, libxkbcommon), Ptr{xkb_keymap}, (Ptr{xkb_state},), state)
+end
+
+function xkb_state_update_key(state, key, direction)
+    ccall((:xkb_state_update_key, libxkbcommon), xkb_state_component, (Ptr{xkb_state}, xkb_keycode_t, xkb_key_direction), state, key, direction)
+end
+
+function xkb_state_update_mask(state, depressed_mods, latched_mods, locked_mods, depressed_layout, latched_layout, locked_layout)
+    ccall((:xkb_state_update_mask, libxkbcommon), xkb_state_component, (Ptr{xkb_state}, xkb_mod_mask_t, xkb_mod_mask_t, xkb_mod_mask_t, xkb_layout_index_t, xkb_layout_index_t, xkb_layout_index_t), state, depressed_mods, latched_mods, locked_mods, depressed_layout, latched_layout, locked_layout)
+end
+
+function xkb_state_key_get_syms(state, key, syms_out)
+    ccall((:xkb_state_key_get_syms, libxkbcommon), Cint, (Ptr{xkb_state}, xkb_keycode_t, Ptr{Ptr{xkb_keysym_t}}), state, key, syms_out)
+end
+
+function xkb_state_key_get_utf8(state, key, buffer, size)
+    ccall((:xkb_state_key_get_utf8, libxkbcommon), Cint, (Ptr{xkb_state}, xkb_keycode_t, Cstring, Cint), state, key, buffer, size)
+end
+
+function xkb_state_key_get_utf32(state, key)
+    ccall((:xkb_state_key_get_utf32, libxkbcommon), UInt32, (Ptr{xkb_state}, xkb_keycode_t), state, key)
+end
+
+function xkb_state_key_get_one_sym(state, key)
+    ccall((:xkb_state_key_get_one_sym, libxkbcommon), xkb_keysym_t, (Ptr{xkb_state}, xkb_keycode_t), state, key)
+end
+
+function xkb_state_key_get_layout(state, key)
+    ccall((:xkb_state_key_get_layout, libxkbcommon), xkb_layout_index_t, (Ptr{xkb_state}, xkb_keycode_t), state, key)
+end
+
+function xkb_state_key_get_level(state, key, layout)
+    ccall((:xkb_state_key_get_level, libxkbcommon), xkb_level_index_t, (Ptr{xkb_state}, xkb_keycode_t, xkb_layout_index_t), state, key, layout)
+end
+
+function xkb_state_serialize_mods(state, components)
+    ccall((:xkb_state_serialize_mods, libxkbcommon), xkb_mod_mask_t, (Ptr{xkb_state}, xkb_state_component), state, components)
+end
+
+function xkb_state_serialize_layout(state, components)
+    ccall((:xkb_state_serialize_layout, libxkbcommon), xkb_layout_index_t, (Ptr{xkb_state}, xkb_state_component), state, components)
+end
+
+function xkb_state_mod_name_is_active(state, name, type)
+    ccall((:xkb_state_mod_name_is_active, libxkbcommon), Cint, (Ptr{xkb_state}, Cstring, xkb_state_component), state, name, type)
+end
+
+function xkb_state_mod_index_is_active(state, idx, type)
+    ccall((:xkb_state_mod_index_is_active, libxkbcommon), Cint, (Ptr{xkb_state}, xkb_mod_index_t, xkb_state_component), state, idx, type)
+end
+
+function xkb_state_key_get_consumed_mods2(state, key, mode)
+    ccall((:xkb_state_key_get_consumed_mods2, libxkbcommon), xkb_mod_mask_t, (Ptr{xkb_state}, xkb_keycode_t, xkb_consumed_mode), state, key, mode)
+end
+
+function xkb_state_key_get_consumed_mods(state, key)
+    ccall((:xkb_state_key_get_consumed_mods, libxkbcommon), xkb_mod_mask_t, (Ptr{xkb_state}, xkb_keycode_t), state, key)
+end
+
+function xkb_state_mod_index_is_consumed2(state, key, idx, mode)
+    ccall((:xkb_state_mod_index_is_consumed2, libxkbcommon), Cint, (Ptr{xkb_state}, xkb_keycode_t, xkb_mod_index_t, xkb_consumed_mode), state, key, idx, mode)
+end
+
+function xkb_state_mod_index_is_consumed(state, key, idx)
+    ccall((:xkb_state_mod_index_is_consumed, libxkbcommon), Cint, (Ptr{xkb_state}, xkb_keycode_t, xkb_mod_index_t), state, key, idx)
+end
+
+function xkb_state_mod_mask_remove_consumed(state, key, mask)
+    ccall((:xkb_state_mod_mask_remove_consumed, libxkbcommon), xkb_mod_mask_t, (Ptr{xkb_state}, xkb_keycode_t, xkb_mod_mask_t), state, key, mask)
+end
+
+function xkb_state_layout_name_is_active(state, name, type)
+    ccall((:xkb_state_layout_name_is_active, libxkbcommon), Cint, (Ptr{xkb_state}, Cstring, xkb_state_component), state, name, type)
+end
+
+function xkb_state_layout_index_is_active(state, idx, type)
+    ccall((:xkb_state_layout_index_is_active, libxkbcommon), Cint, (Ptr{xkb_state}, xkb_layout_index_t, xkb_state_component), state, idx, type)
+end
+
+function xkb_state_led_name_is_active(state, name)
+    ccall((:xkb_state_led_name_is_active, libxkbcommon), Cint, (Ptr{xkb_state}, Cstring), state, name)
+end
+
+function xkb_state_led_index_is_active(state, idx)
+    ccall((:xkb_state_led_index_is_active, libxkbcommon), Cint, (Ptr{xkb_state}, xkb_led_index_t), state, idx)
+end

--- a/gen/xkb_api.jl
+++ b/gen/xkb_api.jl
@@ -289,3 +289,22 @@ end
 function xkb_state_led_index_is_active(state, idx)
     ccall((:xkb_state_led_index_is_active, libxkbcommon), Cint, (Ptr{xkb_state}, xkb_led_index_t), state, idx)
 end
+# Julia wrapper for header: xkbcommon-x11.h
+# Automatically generated using Clang.jl
+
+
+function xkb_x11_setup_xkb_extension(connection, major_xkb_version, minor_xkb_version, flags, major_xkb_version_out, minor_xkb_version_out, base_event_out, base_error_out)
+    ccall((:xkb_x11_setup_xkb_extension, libxkbcommon), Cint, (Ptr{xcb_connection_t}, UInt16, UInt16, xkb_x11_setup_xkb_extension_flags, Ptr{UInt16}, Ptr{UInt16}, Ptr{UInt8}, Ptr{UInt8}), connection, major_xkb_version, minor_xkb_version, flags, major_xkb_version_out, minor_xkb_version_out, base_event_out, base_error_out)
+end
+
+function xkb_x11_get_core_keyboard_device_id(connection)
+    ccall((:xkb_x11_get_core_keyboard_device_id, libxkbcommon), Int32, (Ptr{xcb_connection_t},), connection)
+end
+
+function xkb_x11_keymap_new_from_device(context, connection, device_id, flags)
+    ccall((:xkb_x11_keymap_new_from_device, libxkbcommon), Ptr{xkb_keymap}, (Ptr{xkb_context}, Ptr{xcb_connection_t}, Int32, xkb_keymap_compile_flags), context, connection, device_id, flags)
+end
+
+function xkb_x11_state_new_from_device(keymap, connection, device_id)
+    ccall((:xkb_x11_state_new_from_device, libxkbcommon), Ptr{xkb_state}, (Ptr{xkb_keymap}, Ptr{xcb_connection_t}, Int32), keymap, connection, device_id)
+end

--- a/gen/xkb_api.jl
+++ b/gen/xkb_api.jl
@@ -294,17 +294,17 @@ end
 
 
 function xkb_x11_setup_xkb_extension(connection, major_xkb_version, minor_xkb_version, flags, major_xkb_version_out, minor_xkb_version_out, base_event_out, base_error_out)
-    ccall((:xkb_x11_setup_xkb_extension, libxkbcommon), Cint, (Ptr{xcb_connection_t}, UInt16, UInt16, xkb_x11_setup_xkb_extension_flags, Ptr{UInt16}, Ptr{UInt16}, Ptr{UInt8}, Ptr{UInt8}), connection, major_xkb_version, minor_xkb_version, flags, major_xkb_version_out, minor_xkb_version_out, base_event_out, base_error_out)
+    ccall((:xkb_x11_setup_xkb_extension, libxkbcommon_x11), Cint, (Ptr{xcb_connection_t}, UInt16, UInt16, xkb_x11_setup_xkb_extension_flags, Ptr{UInt16}, Ptr{UInt16}, Ptr{UInt8}, Ptr{UInt8}), connection, major_xkb_version, minor_xkb_version, flags, major_xkb_version_out, minor_xkb_version_out, base_event_out, base_error_out)
 end
 
 function xkb_x11_get_core_keyboard_device_id(connection)
-    ccall((:xkb_x11_get_core_keyboard_device_id, libxkbcommon), Int32, (Ptr{xcb_connection_t},), connection)
+    ccall((:xkb_x11_get_core_keyboard_device_id, libxkbcommon_x11), Int32, (Ptr{xcb_connection_t},), connection)
 end
 
 function xkb_x11_keymap_new_from_device(context, connection, device_id, flags)
-    ccall((:xkb_x11_keymap_new_from_device, libxkbcommon), Ptr{xkb_keymap}, (Ptr{xkb_context}, Ptr{xcb_connection_t}, Int32, xkb_keymap_compile_flags), context, connection, device_id, flags)
+    ccall((:xkb_x11_keymap_new_from_device, libxkbcommon_x11), Ptr{xkb_keymap}, (Ptr{xkb_context}, Ptr{xcb_connection_t}, Int32, xkb_keymap_compile_flags), context, connection, device_id, flags)
 end
 
 function xkb_x11_state_new_from_device(keymap, connection, device_id)
-    ccall((:xkb_x11_state_new_from_device, libxkbcommon), Ptr{xkb_state}, (Ptr{xkb_keymap}, Ptr{xcb_connection_t}, Int32), keymap, connection, device_id)
+    ccall((:xkb_x11_state_new_from_device, libxkbcommon_x11), Ptr{xkb_state}, (Ptr{xkb_keymap}, Ptr{xcb_connection_t}, Int32), keymap, connection, device_id)
 end

--- a/gen/xkb_common.jl
+++ b/gen/xkb_common.jl
@@ -1,0 +1,93 @@
+# Automatically generated using Clang.jl
+
+
+const XKB_KEYCODE_INVALID = Float32(0x0fffffff)
+const XKB_LAYOUT_INVALID = Float32(0x0fffffff)
+const XKB_LEVEL_INVALID = Float32(0x0fffffff)
+const XKB_MOD_INVALID = Float32(0x0fffffff)
+const XKB_LED_INVALID = Float32(0x0fffffff)
+const XKB_KEYCODE_MAX = Float32(0x0fffffff) - 1
+
+# Skipping MacroDefinition: xkb_keycode_is_legal_ext ( key ) ( key <= XKB_KEYCODE_MAX )
+# Skipping MacroDefinition: xkb_keycode_is_legal_x11 ( key ) ( key >= 8 && key <= 255 )
+# Skipping MacroDefinition: XKB_KEYMAP_USE_ORIGINAL_FORMAT ( ( enum xkb_keymap_format ) - 1 )
+
+const xkb_context = Cvoid
+const xkb_keymap = Cvoid
+const xkb_state = Cvoid
+const xkb_keycode_t = UInt32
+const xkb_keysym_t = UInt32
+const xkb_layout_index_t = UInt32
+const xkb_layout_mask_t = UInt32
+const xkb_level_index_t = UInt32
+const xkb_mod_index_t = UInt32
+const xkb_mod_mask_t = UInt32
+const xkb_led_index_t = UInt32
+const xkb_led_mask_t = UInt32
+
+struct xkb_rule_names
+    rules::Cstring
+    model::Cstring
+    layout::Cstring
+    variant::Cstring
+    options::Cstring
+end
+
+@cenum xkb_keysym_flags::UInt32 begin
+    XKB_KEYSYM_NO_FLAGS = 0
+    XKB_KEYSYM_CASE_INSENSITIVE = 1
+end
+
+@cenum xkb_context_flags::UInt32 begin
+    XKB_CONTEXT_NO_FLAGS = 0
+    XKB_CONTEXT_NO_DEFAULT_INCLUDES = 1
+    XKB_CONTEXT_NO_ENVIRONMENT_NAMES = 2
+end
+
+@cenum xkb_log_level::UInt32 begin
+    XKB_LOG_LEVEL_CRITICAL = 10
+    XKB_LOG_LEVEL_ERROR = 20
+    XKB_LOG_LEVEL_WARNING = 30
+    XKB_LOG_LEVEL_INFO = 40
+    XKB_LOG_LEVEL_DEBUG = 50
+end
+
+@cenum xkb_keymap_compile_flags::UInt32 begin
+    XKB_KEYMAP_COMPILE_NO_FLAGS = 0
+end
+
+@cenum xkb_keymap_format::UInt32 begin
+    XKB_KEYMAP_FORMAT_TEXT_V1 = 1
+end
+
+
+const xkb_keymap_key_iter_t = Ptr{Cvoid}
+
+@cenum xkb_key_direction::UInt32 begin
+    XKB_KEY_UP = 0
+    XKB_KEY_DOWN = 1
+end
+
+@cenum xkb_state_component::UInt32 begin
+    XKB_STATE_MODS_DEPRESSED = 1
+    XKB_STATE_MODS_LATCHED = 2
+    XKB_STATE_MODS_LOCKED = 4
+    XKB_STATE_MODS_EFFECTIVE = 8
+    XKB_STATE_LAYOUT_DEPRESSED = 16
+    XKB_STATE_LAYOUT_LATCHED = 32
+    XKB_STATE_LAYOUT_LOCKED = 64
+    XKB_STATE_LAYOUT_EFFECTIVE = 128
+    XKB_STATE_LEDS = 256
+end
+
+@cenum xkb_state_match::UInt32 begin
+    XKB_STATE_MATCH_ANY = 1
+    XKB_STATE_MATCH_ALL = 2
+    XKB_STATE_MATCH_NON_EXCLUSIVE = 65536
+end
+
+@cenum xkb_consumed_mode::UInt32 begin
+    XKB_CONSUMED_MODE_XKB = 0
+    XKB_CONSUMED_MODE_GTK = 1
+end
+

--- a/gen/xkb_common.jl
+++ b/gen/xkb_common.jl
@@ -91,3 +91,11 @@ end
     XKB_CONSUMED_MODE_GTK = 1
 end
 
+
+const XKB_X11_MIN_MAJOR_XKB_VERSION = 1
+const XKB_X11_MIN_MINOR_XKB_VERSION = 0
+
+@cenum xkb_x11_setup_xkb_extension_flags::UInt32 begin
+    XKB_X11_SETUP_XKB_EXTENSION_NO_FLAGS = 0
+end
+

--- a/src/XCB.jl
+++ b/src/XCB.jl
@@ -38,7 +38,8 @@ import WindowAbstractions: set_title,
                            KeyModifierState,
                            KeyContext,
                            KeyCombination,
-                           EventDetails
+                           EventDetails,
+                           KeySymbol
 
 include(joinpath(@__DIR__, "..", "gen", "Libxcb.jl"))
 include(joinpath(@__DIR__, "..", "gen", "Libxkb.jl"))

--- a/src/XCB.jl
+++ b/src/XCB.jl
@@ -44,7 +44,7 @@ include(joinpath(@__DIR__, "..", "gen", "Libxcb.jl"))
 include(joinpath(@__DIR__, "..", "gen", "Libxkb.jl"))
 const xcb = Libxcb
 using .Libxcb
-import .Libxkb
+using .Libxkb
 
 include("exceptions.jl")
 include("connection.jl")

--- a/src/XCB.jl
+++ b/src/XCB.jl
@@ -41,8 +41,10 @@ import WindowAbstractions: set_title,
                            EventDetails
 
 include(joinpath(@__DIR__, "..", "gen", "Libxcb.jl"))
+include(joinpath(@__DIR__, "..", "gen", "Libxkb.jl"))
 const xcb = Libxcb
 using .Libxcb
+import .Libxkb
 
 include("exceptions.jl")
 include("connection.jl")

--- a/src/XCB.jl
+++ b/src/XCB.jl
@@ -54,6 +54,7 @@ include("xkb.jl")
 include("window_handler.jl")
 include("context.jl")
 include("testing.jl")
+include("events.jl")
 
 
 export xcb,
@@ -74,6 +75,7 @@ export xcb,
        keymap_info,
        key_info,
        name_from_keycode,
-       name_from_keysym
+       name_from_keysym,
+       unsafe_load_event
 
 end # module

--- a/src/XCB.jl
+++ b/src/XCB.jl
@@ -49,9 +49,10 @@ using .Libxkb
 include("exceptions.jl")
 include("connection.jl")
 include("window.jl")
+include("inputs.jl")
+include("xkb.jl")
 include("window_handler.jl")
 include("context.jl")
-include("inputs.jl")
 include("testing.jl")
 
 
@@ -67,6 +68,12 @@ export xcb,
        XWindowHandler,
        get_window,
        get_window_symbol,
-       event_details
+       event_details_xkb,
+       @check,
+       @flush,
+       keymap_info,
+       key_info,
+       name_from_keycode,
+       name_from_keysym
 
 end # module

--- a/src/connection.jl
+++ b/src/connection.jl
@@ -152,6 +152,7 @@ macro check(request)
     has_module_prefix = startswith(request_fun, module_prefix)
     has_module_prefix && (request_fun = request_fun[5:end])
     
+    # get checked version of the request function
     if endswith(request_fun, "_unchecked")
         request_fun_checked = replace(request_fun, "_unchecked" => "")
     elseif !endswith(request_fun, "_checked")
@@ -163,12 +164,14 @@ macro check(request)
     else
         request_fun_checked = request_fun
     end
+    # restore module prefix and add it to `check_request` as well if relevant
     if has_module_prefix
         request_fun_checked = module_prefix * request_fun_checked
         check_request_fun = Meta.parse(module_prefix * "check_request")
     else
         check_request_fun = :check_request
     end
+    # change the request function in the original expr
     if isdefined(@__MODULE__, Symbol(replace(request_fun_checked, module_prefix => "")))
         request.args[1] = Meta.parse(request_fun_checked)
     else

--- a/src/events.jl
+++ b/src/events.jl
@@ -1,0 +1,22 @@
+event_type(::Val{XCB_CONFIGURE_NOTIFY}) = xcb_configure_notify_event_t
+event_type(::Union{Val{XCB_KEY_PRESS}, Val{XCB_KEY_RELEASE}}) = xcb_key_press_event_t
+event_type(::Union{Val{XCB_ENTER_NOTIFY}, Val{XCB_LEAVE_NOTIFY}}) = xcb_enter_notify_event_t
+event_type(::Union{Val{XCB_BUTTON_PRESS}, Val{XCB_BUTTON_RELEASE}}) = xcb_button_press_event_t
+event_type(::Val{XCB_MOTION_NOTIFY}) = xcb_motion_notify_event_t
+event_type(::Val{XCB_EXPOSE}) = xcb_expose_event_t
+event_type(::Val{XCB_CLIENT_MESSAGE}) = xcb_client_message_event_t
+event_type(::Union{Val{85}}) = xcb.xcb_xkb_state_notify_event_t # very hacky, but response type XCB_XKB_STATE_NOTIFY never gets signaled and 85 is emitted instead...
+event_type(::Val{XCB_KEYMAP_NOTIFY}) = xcb_keymap_notify_event_t
+event_type(rt) = nothing
+
+function unsafe_load_event(xge_ptr; warn_unknown=false)
+    xge = unsafe_load(xge_ptr)
+    rt = xge.response_type % 128
+    et = event_type(Val(Int(rt)))
+    if isnothing(et)
+        warn_unknown && @warn "Unknown event $(xge.response_type) (modulo 128: $rt)"
+        nothing
+    else
+        unsafe_load(convert(Ptr{et}, xge_ptr))
+    end
+end

--- a/src/events.jl
+++ b/src/events.jl
@@ -5,7 +5,7 @@ event_type(::Union{Val{XCB_BUTTON_PRESS}, Val{XCB_BUTTON_RELEASE}}) = xcb_button
 event_type(::Val{XCB_MOTION_NOTIFY}) = xcb_motion_notify_event_t
 event_type(::Val{XCB_EXPOSE}) = xcb_expose_event_t
 event_type(::Val{XCB_CLIENT_MESSAGE}) = xcb_client_message_event_t
-event_type(::Union{Val{85}}) = xcb.xcb_xkb_state_notify_event_t # very hacky, but response type XCB_XKB_STATE_NOTIFY never gets signaled and 85 is emitted instead...
+event_type(::Val{85}) = xcb.xcb_xkb_state_notify_event_t # very hacky, but response type 85 is emitted instead of XCB_XKB_STATE_NOTIFY...
 event_type(::Val{XCB_KEYMAP_NOTIFY}) = xcb_keymap_notify_event_t
 event_type(rt) = nothing
 
@@ -20,3 +20,29 @@ function unsafe_load_event(xge_ptr; warn_unknown=false)
         unsafe_load(convert(Ptr{et}, xge_ptr))
     end
 end
+
+window_id_field(event::xcb_button_press_event_t) = :event
+window_id_field(event::xcb_key_press_event_t) = :event
+window_id_field(event::xcb_configure_notify_event_t) = :window
+window_id_field(event::xcb_expose_event_t) = :window
+window_id_field(event::xcb_enter_notify_event_t) = :event
+window_id_field(event::xcb_motion_notify_event_t) = :event
+window_id_field(event::xcb_client_message_event_t) = :window
+
+window_id(event) = getproperty(event, window_id_field(event))
+
+WindowAbstractions.Point2(event::xcb_button_press_event_t) = Point2{Int}(event.event_x, event.event_y)
+WindowAbstractions.Point2(event::xcb_key_press_event_t) = Point2{Int}(event.event_x, event.event_y)
+WindowAbstractions.Point2(event::xcb_configure_notify_event_t) = Point2{Int}(event.x, event.y)
+WindowAbstractions.Point2(event::xcb_expose_event_t) = Point2{Int}(event.x, event.y)
+WindowAbstractions.Point2(event::xcb_enter_notify_event_t) = Point2{Int}(event.event_x, event.event_y)
+WindowAbstractions.Point2(event::xcb_motion_notify_event_t) = Point2{Int}(event.event_x, event.event_y)
+
+EventDetails(handler::XWindowHandler, window::XCBWindow, data::EventData, event, t) = EventDetails(data, Point2(event), t, get_window_symbol(handler, window), window, handler)
+
+EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_button_press_event_t, t) = EventDetails(handler, window, MouseEvent(data), data, t)
+EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_key_press_event_t, t) = EventDetails(handler, window, KeyEvent(Symbol(name_from_keycode(handler.keymap, data.detail)), KeySymbol(handler.keymap, data.detail), Char(handler.keymap, data.detail), KeyModifierState(data), data.response_type == XCB_KEY_PRESS ? KeyPressed() : KeyReleased()), data, t)
+EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_configure_notify_event_t, t) = EventDetails(handler, window, ResizeEvent(Point2{Int}(data.width, data.height)), data, t)
+EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_expose_event_t, t) = EventDetails(handler, window, ExposeEvent(Point2{Int}(data.width, data.height), data.count), data, t)
+EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_enter_notify_event_t, t) = EventDetails(handler, window, data.response_type == XCB_ENTER_NOTIFY ? PointerEntersWindowEvent() : PointerLeavesWindowEvent(), data, t)
+EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_motion_notify_event_t, t) = EventDetails(handler, window, PointerMovesEvent(), data, t)

--- a/src/inputs.jl
+++ b/src/inputs.jl
@@ -9,14 +9,7 @@ button(xcb_button::XCBButtonCode{Val(3)}) = ButtonRight()
 button(xcb_button::XCBButtonCode{Val(4)}) = ButtonScrollUp()
 button(xcb_button::XCBButtonCode{Val(5)}) = ButtonScrollDown()
 
-function get_key(connection::Connection, key_event::Union{xcb_key_press_event_t,xcb_key_release_event_t})
-    keysymbols = xcb_key_symbols_alloc(connection)
-    keysym = xcb_key_symbols_get_keysym(keysymbols, key_event.detail, 0)
-    @show keysym Char(keysym)
-    Char(keysym)
-end
-
-KeyCombination(connection::Connection, key_event::Union{xcb_key_press_event_t,xcb_key_release_event_t}) = KeyCombination(get_key(connection, key_event), KeyModifierState(key_event))
+KeyCombination(km, key_event::Union{xcb_key_press_event_t,xcb_key_release_event_t}) = KeyCombination(get_key(km, key_event.detail), KeyModifierState(key_event))
 
 function KeyContext(key_event::Union{xcb_key_press_event_t,xcb_key_release_event_t})
     state = key_event.state
@@ -29,22 +22,5 @@ function KeyModifierState(key_event::Union{xcb_key_press_event_t,xcb_key_release
 end
 
 MouseState(mouse_event::Union{xcb_button_press_event_t, xcb_button_release_event_t}) = MouseState((mouse_event.state .| [XCB_BUTTON_MASK_1, XCB_BUTTON_MASK_2, XCB_BUTTON_MASK_3, XCB_BUTTON_MASK_4, XCB_BUTTON_MASK_5, XCB_BUTTON_MASK_ANY] .== mouse_event.state)...)
-
-_xcb_translate_state(s::MouseState) = .&(UInt[s.left, s.middle, s.right, s.scroll_up, s.scroll_down, s.any] .* [XCB_BUTTON_MASK_1, XCB_BUTTON_MASK_2, XCB_BUTTON_MASK_3, XCB_BUTTON_MASK_4, XCB_BUTTON_MASK_5, XCB_BUTTON_MASK_ANY]...)
-
-_xcb_translate_event(::Type{ButtonPressed}) = XCB_BUTTON_PRESS
-_xcb_translate_event(::Type{ButtonReleased}) = XCB_BUTTON_RELEASE
-_xcb_translate_event(::KeyPressed) = XCB_KEY_PRESS
-_xcb_translate_event(::KeyReleased) = XCB_KEY_RELEASE
-_xcb_translate_event(::PointerMoves) = XCB_MOTION_NOTIFY
-_xcb_translate_event(::PointerEntersWindow) = XCB_ENTER_NOTIFY
-_xcb_translate_event(::PointerLeavesWindow) = XCB_LEAVE_NOTIFY
-_xcb_translate_event(::ExposeEvent) = XCB_EXPOSE
-
-_xcb_translate_button(::ButtonLeft) = XCB_BUTTON_MASK_1
-_xcb_translate_button(::ButtonMiddle) = XCB_BUTTON_MASK_2
-_xcb_translate_button(::ButtonRight) = XCB_BUTTON_MASK_3
-_xcb_translate_button(::ButtonScrollUp) = XCB_BUTTON_MASK_4
-_xcb_translate_button(::ButtonScrollDown) = XCB_BUTTON_MASK_5
 
 MouseEvent(mouse_event::xcb_button_press_event_t) = MouseEvent(button(XCBButtonCode(Val(Int(mouse_event.detail)))), MouseState(mouse_event), mouse_event.response_type == XCB_BUTTON_PRESS ? ButtonPressed() : ButtonReleased())

--- a/src/testing.jl
+++ b/src/testing.jl
@@ -1,3 +1,22 @@
+_xcb_translate_state(s::MouseState) = .&(UInt[s.left, s.middle, s.right, s.scroll_up, s.scroll_down, s.any] .* [XCB_BUTTON_MASK_1, XCB_BUTTON_MASK_2, XCB_BUTTON_MASK_3, XCB_BUTTON_MASK_4, XCB_BUTTON_MASK_5, XCB_BUTTON_MASK_ANY]...)
+
+_xcb_translate_event(::Type{ButtonPressed}) = XCB_BUTTON_PRESS
+_xcb_translate_event(::Type{ButtonReleased}) = XCB_BUTTON_RELEASE
+_xcb_translate_event(::KeyPressed) = XCB_KEY_PRESS
+_xcb_translate_event(::KeyReleased) = XCB_KEY_RELEASE
+_xcb_translate_event(::PointerMoves) = XCB_MOTION_NOTIFY
+_xcb_translate_event(::PointerEntersWindow) = XCB_ENTER_NOTIFY
+_xcb_translate_event(::PointerLeavesWindow) = XCB_LEAVE_NOTIFY
+_xcb_translate_event(::ExposeEvent) = XCB_EXPOSE
+
+_xcb_translate_button(::ButtonLeft) = XCB_BUTTON_MASK_1
+_xcb_translate_button(::ButtonMiddle) = XCB_BUTTON_MASK_2
+_xcb_translate_button(::ButtonRight) = XCB_BUTTON_MASK_3
+_xcb_translate_button(::ButtonScrollUp) = XCB_BUTTON_MASK_4
+_xcb_translate_button(::ButtonScrollDown) = XCB_BUTTON_MASK_5
+
 send_xevent(window::XCBWindow, ed::EventData) = @flush @check xcb_send_event(window.conn, false, window.id, window.mask, xevent(w, ed))
 
 xevent(w::XCBWindow, e::EventDetails{MouseEvent{E}}) where {E} = xcb_button_press_event_t(_xcb_translate_event(E), _xcb_translate_button(e.data.button), e.time, w.parent_id, w.id, 0, 0, e.location..., _xcb_translate_state(e.data.state))
+
+hex(x) = "0x$(string(x, base=16))"

--- a/src/window_handler.jl
+++ b/src/window_handler.jl
@@ -21,32 +21,6 @@ function terminate_window!(handler::XWindowHandler, win::XCBWindow)
     finalize(win)
 end
 
-window_id_field(event::xcb_button_press_event_t) = :event
-window_id_field(event::xcb_key_press_event_t) = :event
-window_id_field(event::xcb_configure_notify_event_t) = :window
-window_id_field(event::xcb_expose_event_t) = :window
-window_id_field(event::xcb_enter_notify_event_t) = :event
-window_id_field(event::xcb_motion_notify_event_t) = :event
-window_id_field(event::xcb_client_message_event_t) = :window
-
-window_id(event) = getproperty(event, window_id_field(event))
-
-WindowAbstractions.Point2(event::xcb_button_press_event_t) = Point2{Int}(event.event_x, event.event_y)
-WindowAbstractions.Point2(event::xcb_key_press_event_t) = Point2{Int}(event.event_x, event.event_y)
-WindowAbstractions.Point2(event::xcb_configure_notify_event_t) = Point2{Int}(event.x, event.y)
-WindowAbstractions.Point2(event::xcb_expose_event_t) = Point2{Int}(event.x, event.y)
-WindowAbstractions.Point2(event::xcb_enter_notify_event_t) = Point2{Int}(event.event_x, event.event_y)
-WindowAbstractions.Point2(event::xcb_motion_notify_event_t) = Point2{Int}(event.event_x, event.event_y)
-
-EventDetails(handler::XWindowHandler, window::XCBWindow, data::EventData, event, t) = EventDetails(data, Point2(event), t, get_window_symbol(handler, window), window, handler)
-
-EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_button_press_event_t, t) = EventDetails(handler, window, MouseEvent(data), data, t)
-EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_key_press_event_t, t) = EventDetails(handler, window, KeyEvent(KeyCombination(handler.keymap, data), data.response_type == XCB_KEY_PRESS ? KeyPressed() : KeyReleased()), data, t)
-EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_configure_notify_event_t, t) = EventDetails(handler, window, ResizeEvent(Point2{Int}(data.width, data.height)), data, t)
-EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_expose_event_t, t) = EventDetails(handler, window, ExposeEvent(Point2{Int}(data.width, data.height), data.count), data, t)
-EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_enter_notify_event_t, t) = EventDetails(handler, window, data.response_type == XCB_ENTER_NOTIFY ? PointerEntersWindowEvent() : PointerLeavesWindowEvent(), data, t)
-EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_motion_notify_event_t, t) = EventDetails(handler, window, PointerMovesEvent(), data, t)
-
 function get_window(handler::XWindowHandler, id::Integer)
     windows = collect(values(handler.windows))
     index = findfirst(x -> id == x.id, windows)

--- a/src/window_handler.jl
+++ b/src/window_handler.jl
@@ -1,8 +1,10 @@
-struct XWindowHandler <: AbstractWindowHandler
+mutable struct XWindowHandler <: AbstractWindowHandler
     conn::Connection
     windows::Dict{Symbol, XCBWindow}
+    keymap::Keymap
 end
-XWindowHandler(conn, windows::Vector{XCBWindow}) = XWindowHandler(conn, Dict(Symbol.("window_" .* string.(1:length(windows))) .=> windows))
+XWindowHandler(conn::Connection, windows::Dict{Symbol, XCBWindow}) = XWindowHandler(conn, windows, Keymap(conn))
+XWindowHandler(conn::Connection, windows::Vector{XCBWindow}) = XWindowHandler(conn, Dict(Symbol.("window_" .* string.(1:length(windows))) .=> windows))
 
 function poll_for_event(handler::XWindowHandler, t0)
     event = xcb_poll_for_event(handler.conn)
@@ -39,7 +41,7 @@ WindowAbstractions.Point2(event::xcb_motion_notify_event_t) = Point2{Int}(event.
 EventDetails(handler::XWindowHandler, window::XCBWindow, data::EventData, event, t) = EventDetails(data, Point2(event), t, get_window_symbol(handler, window), window, handler)
 
 EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_button_press_event_t, t) = EventDetails(handler, window, MouseEvent(data), data, t)
-EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_key_press_event_t, t) = EventDetails(handler, window, KeyEvent(KeyCombination(handler.conn, data), data.response_type == XCB_KEY_PRESS ? KeyPressed() : KeyReleased()), data, t)
+EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_key_press_event_t, t) = EventDetails(handler, window, KeyEvent(KeyCombination(handler.keymap, data), data.response_type == XCB_KEY_PRESS ? KeyPressed() : KeyReleased()), data, t)
 EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_configure_notify_event_t, t) = EventDetails(handler, window, ResizeEvent(Point2{Int}(data.width, data.height)), data, t)
 EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_expose_event_t, t) = EventDetails(handler, window, ExposeEvent(Point2{Int}(data.width, data.height), data.count), data, t)
 EventDetails(handler::XWindowHandler, window::XCBWindow, data::xcb_enter_notify_event_t, t) = EventDetails(handler, window, data.response_type == XCB_ENTER_NOTIFY ? PointerEntersWindowEvent() : PointerLeavesWindowEvent(), data, t)
@@ -52,6 +54,8 @@ function get_window(handler::XWindowHandler, id::Integer)
     windows[index]
 end
 
+get_window(handler::XWindowHandler, event::xcb_xkb_state_notify_event_t) = nothing
+get_window(handler::XWindowHandler, event::xcb_keymap_notify_event_t) = nothing
 get_window(handler::XWindowHandler, event) = get_window(handler, window_id(event))
 get_window(handler::XWindowHandler, id::Symbol) = handler.windows[id]
 get_window_symbol(handler::XWindowHandler, window::XCBWindow) = collect(keys(handler.windows))[findfirst(values(handler.windows) .== window)]

--- a/src/xkb.jl
+++ b/src/xkb.jl
@@ -1,0 +1,77 @@
+mutable struct Keymap <: Handle
+    h::Ptr{xkb_keymap}
+    ctx::Ptr{xkb_context}
+    state::Ptr{xkb_state}
+    conn::Connection
+    device_id
+    function Keymap(h, ctx, state, conn, id)
+        km = new(h, ctx, state, conn, id)
+        finalizer(km) do x
+            xkb_state_unref(x.state)
+            xkb_keymap_unref(x.h)
+            xkb_context_unref(x.ctx)
+        end
+    end
+end
+
+function event_details_xkb(fields::Dict{String, Bool})
+    names = fieldnames(xcb_xkb_select_events_details_t)
+    flags = zeros(length(names))
+    fields_affect = Dict("affect" * uppercasefirst(k) => v for (k, v) ∈ fields)
+    for i ∈ 1:2:length(names)
+        access_field = string(names[i])
+        if access_field ∈ keys(fields_affect)
+            flags[i] = 1 # affect
+            flags[i + 1] = fields_affect[access_field] # details
+        end
+    end
+    xcb_xkb_select_events_details_t(flags...)
+end
+
+function Keymap(conn::Connection; setup_xkb=true)
+    setup_xkb && @assert Bool(xkb_x11_setup_xkb_extension(conn, 1, 0, XKB_X11_SETUP_XKB_EXTENSION_NO_FLAGS, C_NULL, C_NULL, C_NULL, C_NULL))
+    ctx = xkb_context_new(XKB_CONTEXT_NO_DEFAULT_INCLUDES)
+    ctx == C_NULL && error("Context could not be created: $ctx")
+    device_id = xkb_x11_get_core_keyboard_device_id(conn)
+    device_id == -1 && error("Invalid device ID retrieved: $device_id")
+    keymap = xkb_x11_keymap_new_from_device(ctx, conn, device_id, XKB_KEYMAP_COMPILE_NO_FLAGS)
+    state = xkb_x11_state_new_from_device(keymap, conn, device_id)
+    state == C_NULL && error("State could not be created: $state")
+    Keymap(keymap, ctx, state, conn, device_id)
+end
+
+function keymap_info(km)
+    km_name_ptr = xkb_keymap_get_as_string(km, XKB_KEYMAP_FORMAT_TEXT_V1)
+    km_name_ptr == C_NULL && error("Could not fetch keymap name")
+    unsafe_string(km_name_ptr)
+end
+
+
+function name_from_keysym(keysym; max_chars=50)
+    char_tmp = zeros(UInt8, max_chars)
+    char_tmp_ptr = pointer(char_tmp)
+    GC.@preserve char_tmp begin
+        val = xkb_keysym_get_name(keysym, pointer(char_tmp), sizeof(eltype(char_tmp)) * length(char_tmp))
+        val == -1 && @error("Could not find keysym name for $(hex(keysym))")
+        str = unsafe_string(char_tmp_ptr)
+    end
+    str
+end
+
+function name_from_keycode(km::Keymap, keycode)
+    ptr = xkb_keymap_key_get_name(km, keycode)
+    ptr == C_NULL && error("Could not get name from keycode $keycode")
+    unsafe_string(ptr)
+end
+
+function key_info(km, keycode)
+    sym = xkb_state_key_get_one_sym(km.state, keycode)
+    """
+    Keycode \e[33m$(keycode)\e[m:
+        keycode name: \e[36m$(name_from_keycode(km, keycode))\e[m
+                 sym: \e[36m$(hex(sym))\e[m
+         keysym name: \e[36m$(name_from_keysym(sym))\e[m
+    """
+end
+
+get_key(km::Keymap, keycode) = begin @info(key_info(km, keycode)); Char(xkb_state_key_get_utf32(km.state, keycode)) end

--- a/test/events.jl
+++ b/test/events.jl
@@ -1,7 +1,6 @@
 function unsafe_load_event(xge_ptr; warn_unknown=false)
     xge = unsafe_load(xge_ptr)
-    rt = xge.response_type
-    rt = rt > 128 ? rt - 128 : rt
+    rt = xge.response_type % 128
     if rt == XCB.XCB_CONFIGURE_NOTIFY
         unsafe_load(convert(Ptr{XCB.xcb_configure_notify_event_t}, xge_ptr))
     elseif rt ∈ (XCB.XCB_KEY_PRESS, XCB.XCB_KEY_RELEASE)
@@ -16,6 +15,10 @@ function unsafe_load_event(xge_ptr; warn_unknown=false)
         unsafe_load(convert(Ptr{XCB.xcb_expose_event_t}, xge_ptr))
     elseif rt == XCB.XCB_CLIENT_MESSAGE
         unsafe_load(convert(Ptr{xcb.xcb_client_message_event_t}, xge_ptr)) # delete window request
+    elseif rt == XCB.XCB_XKB_STATE_NOTIFY || rt == 85 # response type XCB_XKB_STATE_NOTIFY never gets signaled, but 85 is emitted instead...
+        unsafe_load(convert(Ptr{xcb.xcb_xkb_state_notify_event_t}, xge_ptr))
+    elseif rt == XCB.XCB_KEYMAP_NOTIFY
+        unsafe_load(convert(Ptr{xcb.xcb_keymap_notify_event_t}, xge_ptr))
     else
         warn_unknown && @warn "Unknown event $(rt)"
         nothing
@@ -32,6 +35,10 @@ function process_xevent(wh, event_loop, xge, t; warn_unknown=false, kwargs...)
             ed_8 = Int.(event.data.data8)
             event_data32_1 = ed_8[1] + ed_8[2] * 2^8 + ed_8[3] * 2^16 + ed_8[4] *2^24
             event_data32_1 == window.delete_request && throw(CloseWindow(wh, window, ""))
+        elseif event isa XCB.xcb_xkb_state_notify_event_t
+            XCB.xkb_state_update_mask(wh.keymap.state, event.baseMods, event.latchedMods, event.lockedMods, event.baseGroup, event.latchedGroup, event.lockedGroup)
+        elseif event isa XCB.xcb_keymap_notify_event_t
+            wh.keymap = XCB.Keymap(wh.conn; setup_xkb=false)
         elseif !isnothing(window) # event happened on inexistant window
             details = EventDetails(wh, window, event, t)
             execute_callback(event_loop, details; kwargs...)

--- a/test/events.jl
+++ b/test/events.jl
@@ -1,31 +1,3 @@
-function unsafe_load_event(xge_ptr; warn_unknown=false)
-    xge = unsafe_load(xge_ptr)
-    rt = xge.response_type % 128
-    if rt == XCB.XCB_CONFIGURE_NOTIFY
-        unsafe_load(convert(Ptr{XCB.xcb_configure_notify_event_t}, xge_ptr))
-    elseif rt ∈ (XCB.XCB_KEY_PRESS, XCB.XCB_KEY_RELEASE)
-        unsafe_load(convert(Ptr{XCB.xcb_key_press_event_t}, xge_ptr))
-    elseif rt ∈ (XCB.XCB_ENTER_NOTIFY, XCB.XCB_LEAVE_NOTIFY)
-        unsafe_load(convert(Ptr{XCB.xcb_enter_notify_event_t}, xge_ptr))
-    elseif rt ∈ (XCB.XCB_BUTTON_PRESS, XCB.XCB_BUTTON_RELEASE)
-        unsafe_load(convert(Ptr{XCB.xcb_button_press_event_t}, xge_ptr))
-    elseif rt == XCB.XCB_MOTION_NOTIFY
-        unsafe_load(convert(Ptr{XCB.xcb_motion_notify_event_t}, xge_ptr))
-    elseif rt == XCB.XCB_EXPOSE
-        unsafe_load(convert(Ptr{XCB.xcb_expose_event_t}, xge_ptr))
-    elseif rt == XCB.XCB_CLIENT_MESSAGE
-        unsafe_load(convert(Ptr{xcb.xcb_client_message_event_t}, xge_ptr)) # delete window request
-    elseif rt == XCB.XCB_XKB_STATE_NOTIFY || rt == 85 # response type XCB_XKB_STATE_NOTIFY never gets signaled, but 85 is emitted instead...
-        unsafe_load(convert(Ptr{xcb.xcb_xkb_state_notify_event_t}, xge_ptr))
-    elseif rt == XCB.XCB_KEYMAP_NOTIFY
-        unsafe_load(convert(Ptr{xcb.xcb_keymap_notify_event_t}, xge_ptr))
-    else
-        warn_unknown && @warn "Unknown event $(rt)"
-        nothing
-        # throw(ErrorException("Unknown event with response_type $rt"))
-    end
-end
-
 process_xevent(wh, event_loop, xge::Nothing, t; warn_unknown=false, kwargs...) = nothing
 function process_xevent(wh, event_loop, xge, t; warn_unknown=false, kwargs...)
     event = unsafe_load_event(xge; warn_unknown)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ end
 r = Ref(XCB.xcb_rectangle_t(20, 20, 60, 60))
 
 function test()
-    ENV["DISPLAY"] = ":1.0"
+    !get(ENV, "CI", false) && setindex!(ENV, ":1.0", "DISPLAY")
 
     connection = Connection(display=nothing)
     setup = Setup(connection)
@@ -43,22 +43,25 @@ function test()
     println(screen)
     
     value_masks = |(XCB.XCB_CW_BACK_PIXEL, XCB.XCB_CW_EVENT_MASK)
-    value_list = [screen.black_pixel, |(XCB.XCB_EVENT_MASK_EXPOSURE, XCB.XCB_EVENT_MASK_KEY_PRESS, XCB.XCB_EVENT_MASK_KEY_RELEASE, XCB.XCB_EVENT_MASK_BUTTON_PRESS, XCB.XCB_EVENT_MASK_BUTTON_RELEASE, XCB.XCB_EVENT_MASK_STRUCTURE_NOTIFY, XCB.XCB_EVENT_MASK_ENTER_WINDOW, XCB.XCB_EVENT_MASK_LEAVE_WINDOW, XCB.XCB_EVENT_MASK_POINTER_MOTION, XCB.XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT)]
+    value_list = [screen.black_pixel, |(XCB.XCB_EVENT_MASK_EXPOSURE, XCB.XCB_EVENT_MASK_KEY_PRESS, XCB.XCB_EVENT_MASK_KEY_RELEASE, XCB.XCB_EVENT_MASK_BUTTON_PRESS, XCB.XCB_EVENT_MASK_BUTTON_RELEASE, XCB.XCB_EVENT_MASK_STRUCTURE_NOTIFY, XCB.XCB_EVENT_MASK_ENTER_WINDOW, XCB.XCB_EVENT_MASK_LEAVE_WINDOW, XCB.XCB_EVENT_MASK_POINTER_MOTION, XCB.XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT, XCB.XCB_EVENT_MASK_KEYMAP_STATE)]
     
     window = XCBWindow(connection, screen, value_masks, value_list; x=0, y=1000, border_width=50, window_title="XCB window", icon_title="XCB")
-    window_2 = XCBWindow(connection, screen, value_masks, value_list; x=200, y=500, border_width=50, window_title="XCB window 2", icon_title="XCB2")
     println("Window ID: ", window.id)
     mask = |(XCB.XCB_GC_FOREGROUND, XCB.XCB_GC_GRAPHICS_EXPOSURES)
     value_list[1] = screen.black_pixel
     value_list[2] = 0
     ctx = GraphicsContext(connection, window, mask, value_list)
     attach_graphics_context!(window, ctx)
-    ctx_2 = GraphicsContext(connection, window_2, mask, value_list)
-    attach_graphics_context!(window_2, ctx_2)
+    # window_2 = XCBWindow(connection, screen, value_masks, value_list; x=200, y=500, border_width=50, window_title="XCB window 2", icon_title="XCB2")
+    # ctx_2 = GraphicsContext(connection, window_2, mask, value_list)
+    # attach_graphics_context!(window_2, ctx_2)
 
-    a = Channel{Int}(100)
+    handler = XWindowHandler(connection, [window])
 
-    handler = XWindowHandler(connection, [window, window_2])
+    xkb_event_details = event_details_xkb(Dict("state" => true))
+    @show xkb_event_details
+    @check XCB.xcb_xkb_select_events_aux(connection, handler.keymap.device_id, XCB.XCB_XKB_EVENT_TYPE_STATE_NOTIFY, true, true, false, 0, Ref(xkb_event_details))
+
     event_loop = EventLoop(
         window_handler=handler,
         callbacks=Dict(
@@ -67,7 +70,7 @@ function test()
                 on_mouse_button_pressed = on_button_pressed,
                 on_mouse_button_released = x -> @info("Released mouse button $(x.data.button)"),
                 on_key_pressed,
-                on_key_released = x -> println("Released $(x.data.kc)"),
+                # on_key_released = x -> println("Released $(x.data.kc)"),
                 on_pointer_enter = x -> @info("Entering window at $(x.location)"),
                 on_pointer_leave = x -> @info("Leaving window at $(x.location)"),
                 on_pointer_move = x -> @info("Moving pointer at $(x.location)"),
@@ -78,34 +81,8 @@ function test()
             ),
         ),
     )
+    run(event_loop, Synchronous(); warn_unknown=true, poll=true)
 
-    event_loop_2 = EventLoop(
-        window_handler=handler,
-        callbacks=Dict(
-            :window_1 => WindowCallbacks(;
-                on_resize = x -> put!(a, 1),
-                on_mouse_button_pressed = x -> put!(a, 2),
-                on_mouse_button_released = x -> put!(a, 3),
-                on_key_pressed = x -> begin x.data.kc == key"p" && put!(a, 4); on_key_pressed(x) end,
-                on_key_released = x -> x.data.kc == key"p" && put!(a, 5),
-                on_pointer_enter = x -> put!(a, 6),
-                on_pointer_leave = x -> put!(a, 7),
-                on_pointer_move = x -> put!(a, 8),
-                on_expose = x -> put!(a, 9),
-            ),
-            :window_2 => WindowCallbacks(;
-            on_mouse_button_pressed = x -> put!(a, 10),
-            on_key_pressed,
-            ),
-        ),
-    )
-    run(event_loop_2, Synchronous(); warn_unknown=true, poll=true)
-    @test take!(a) == 1
-    @test take!(a) == 1
-    @test take!(a) == 1
-    @test take!(a) == 9
-    XCB.@flush XCB.@check XCB.xcb_send_event
-    @test isempty(a)
 end
 
 test()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,6 @@ function on_key_pressed(details::EventDetails)
     key = details.data.kc
     ctx = win.ctx
     set_title(win, "Random title $(rand())")
-    println("Pressed $key")
     if key ∈ [key"q", key"ctrl+q", key"f4"]
         throw(CloseWindow(details.window_handler, win))
     elseif key == key"s"


### PR DESCRIPTION
I added a generator for xcb-xkb (a header from Xorg_libxcb_jll that was not wrapped) and xkbcommon. I also improved the processing done to retrieve a character from an input event, by keeping track of the keymap state (modifiers pressed such as Shift or Caps lock) and of keymap changes (say, a user switches from AZERTY to QWERTY).